### PR TITLE
Removed quotes from consumer.ini

### DIFF
--- a/OpenStack-Rabbit-Consumer/etc/openstack-utils/consumer.ini
+++ b/OpenStack-Rabbit-Consumer/etc/openstack-utils/consumer.ini
@@ -1,7 +1,7 @@
 [rabbit]
-host=""
-login_user=""
-login_pass=""
+host=
+login_user=
+login_pass=
 port=5672
 exchanges=ceilometer
     central
@@ -23,11 +23,11 @@ exchanges=ceilometer
 auth_url=
 project_id=
 project_name=
-user_domain="stfc"
+user_domain=stfc
 username=
 password=
 region_name=
-cacert="path/to/cacert"
+cacert=path/to/cacert
 
 [kerberos]
-suffix="HTTP/server"
+suffix=HTTP/server


### PR DESCRIPTION
everything after the `=` is interpreted as the value, so the quotes break things.