### PR TITLE
Updates to Rally Scripts

### DIFF
--- a/OpenStack-Rally-Tester/usr/local/bin/rally-extract-results
+++ b/OpenStack-Rally-Tester/usr/local/bin/rally-extract-results
@@ -23,8 +23,8 @@ url = 'http://'+host+'/write?db='+database
 
 nowtime = time.localtime()
 
-print nowtime
-print nowtime.tm_hour
+#print nowtime
+#print nowtime.tm_hour
 
 if nowtime.tm_hour >= 9 and nowtime.tm_hour <=16:
     workhours = True
@@ -39,12 +39,12 @@ with open(sys.argv[1]) as data_file:
 datastring = ''
 metrics = []
 
-print type(data)
+#print type(data)
 
 if isinstance(data, dict):
     print data
     for key in data.keys():
-        print key
+#        print key
         metric = {}
         metric['fields'] = {}
         metric['measurement'] = key
@@ -52,7 +52,9 @@ if isinstance(data, dict):
         metrics.append(metric)
 else:
     for test in data:
-        print test['key']['name']
+
+
+#        print test['key']['name']
         for result in test['result']:
             metric = {}
             metric['fields'] = {}
@@ -60,22 +62,27 @@ else:
 
             metric['fields']['success'] = 1
             for sla in test['sla']:
-                print sla
-                print sla['success']
+#                print sla
+#                print sla['success']
                 if sla['success'] == False:
                    metric['fields']['success'] = 0
 
-            print result['duration']
+#            print result['duration']
             metric['fields']['duration'] = result['duration']
             #metrics.append(metric)
             #print result['timestamp']
             for atomic_action in result['atomic_actions']:
                 metric['fields'][atomic_action] = result['atomic_actions'][atomic_action]
+                #print atomic_action + ' = ' + str(result['atomic_actions'][atomic_action])
+
+            metric['fields']['timestamp'] = result['timestamp']
+
+            if test['key']['name'] == 'VMTasks.boot_runcommand_delete':
+                metric['fields']['image'] = '"' + test['key']['kw']['args']['image']['name'] + '"'
+
             metrics.append(metric)
-                #rint atomic_action + ' = ' + str(result['atomic_actions'][atomic_action])
 
-
-print metrics
+#print metrics
 
 json_metrics = []
 for metric in metrics:
@@ -89,7 +96,7 @@ for metric in metrics:
 
 datastring = datastring
 
-print json_metrics
+print json.dumps(json_metrics, indent=4, sort_keys=True)
 
 print datastring
 

--- a/OpenStack-Rally-Tester/usr/local/bin/rally-run-test
+++ b/OpenStack-Rally-Tester/usr/local/bin/rally-run-test
@@ -2,12 +2,14 @@
 
 rally_test=$1
 
-rally_results_cmd=`rally task start $rally_test | grep "rally task result"`
+echo "This may take some time..."
+rally_results_cmd=`rally task start $rally_test | grep -m 1 "rally task result"`
 echo "$rally_results_cmd"
 if [[ $rally_results_cmd == *'rally task results'* ]]
 then
     rally_task_id=`echo $rally_results_cmd | sed 's/rally task results//g' | sed 's/ //g'`
     echo "$rally_task_id"
+    mkdir -p /tmp/results
     rally_results_path="/tmp/results/$rally_task_id"
     echo $rally_results_path
     $rally_results_cmd > $rally_results_path;


### PR DESCRIPTION
****rally-run-test****
* Added line to create `/tmp/results/` directory if absent
* If multiple `rally task results ...` lines exist, this will only use the first one. Rally benchmarks launched from the same task are stored under the same ID.

****rally-extract-results****
* Added timestamp to output
* Added image name to output when task is `VMTasks.boot_runcommand_delete`