### PR TITLE
Add main method to capi_image_builder

### DIFF
--- a/capi_image_builder/.pylintrc
+++ b/capi_image_builder/.pylintrc
@@ -410,7 +410,6 @@ confidence=HIGH,
 # --disable=W".
 disable=line-too-long,
         missing-module-docstring,
-        missing-function-docstring,
         fixme
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/capi_image_builder/builder/args.py
+++ b/capi_image_builder/builder/args.py
@@ -14,4 +14,5 @@ class Args:
     make_image_public: bool = False
     os_version: str = "2004"
 
-    _is_tmp_dir: bool = False
+    # Set during runtime
+    is_tmp_dir: bool = False

--- a/capi_image_builder/builder/args.py
+++ b/capi_image_builder/builder/args.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Args:
+    """
+    The arguments related to Git operations.
+    """
+
+    target_dir: Optional[str]
+    ssh_key_path: str
+    push_to_github: bool
+    make_image_public: bool = False
+    os_version: str = "2004"
+
+    _is_tmp_dir: bool = False

--- a/capi_image_builder/builder/git_ops.py
+++ b/capi_image_builder/builder/git_ops.py
@@ -16,6 +16,7 @@ class GitOps:
     def git_clone(self, repo_url, target_dir: Path) -> Repo:
         """Clone a git repo to a target directory."""
         self._validate_protocol(repo_url)
+        print(f"Cloning {repo_url} to {target_dir}")
         self.repo = Repo.clone_from(
             repo_url, target_dir, env={"GIT_SSH_COMMAND": f"ssh -i {self.ssh_key_path}"}
         )
@@ -45,4 +46,5 @@ class GitOps:
     def git_rebase_upstream(
         self, remote_name: str = "upstream", branch: str = "master"
     ):
+        print(f"Rebasing {remote_name}/{branch} onto current branch")
         self.repo.git.rebase(f"{remote_name}/{branch}")

--- a/capi_image_builder/builder/git_ops.py
+++ b/capi_image_builder/builder/git_ops.py
@@ -46,5 +46,8 @@ class GitOps:
     def git_rebase_upstream(
         self, remote_name: str = "upstream", branch: str = "master"
     ):
+        """
+        Rebase the current branch onto the upstream branch to bring fork into sync.
+        """
         print(f"Rebasing {remote_name}/{branch} onto current branch")
         self.repo.git.rebase(f"{remote_name}/{branch}")

--- a/capi_image_builder/builder/git_ops.py
+++ b/capi_image_builder/builder/git_ops.py
@@ -13,7 +13,7 @@ class GitOps:
         self.ssh_key_path = ssh_key_path
         self.repo: Optional[Repo] = None
 
-    def git_clone(self, repo_url, target_dir) -> Repo:
+    def git_clone(self, repo_url, target_dir: Path) -> Repo:
         """Clone a git repo to a target directory."""
         self._validate_protocol(repo_url)
         self.repo = Repo.clone_from(

--- a/capi_image_builder/builder/git_steps.py
+++ b/capi_image_builder/builder/git_steps.py
@@ -14,7 +14,7 @@ def populate_temp_dir(arg: Args) -> Args:
     the target directory exists.
     """
     if arg.target_dir is None:
-        arg._is_tmp_dir = True
+        arg.is_tmp_dir = True
         arg.target_dir = mkdtemp()
         print(f"Using temporary directory: {arg.target_dir}")
 

--- a/capi_image_builder/builder/git_steps.py
+++ b/capi_image_builder/builder/git_steps.py
@@ -1,24 +1,11 @@
-from dataclasses import dataclass
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import Optional
 
+from builder.args import Args
 from builder.git_ops import GitOps
 
 K8S_FORK_URL = "git@github.com:stfc/k8s-image-builder.git"
 UPSTREAM_URL = "https://github.com/kubernetes-sigs/image-builder.git"
-
-
-@dataclass
-class Args:
-    """
-    The arguments related to Git operations.
-    """
-
-    target_dir: Optional[str]
-    ssh_key_path: str
-    push_to_github: bool
-    _is_tmp_dir: bool = False
 
 
 def populate_temp_dir(arg: Args) -> Args:

--- a/capi_image_builder/builder/git_steps.py
+++ b/capi_image_builder/builder/git_steps.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import mkdtemp
+from typing import Optional
+
+from builder.git_ops import GitOps
+
+K8S_FORK_URL = "git@github.com:stfc/k8s-image-builder.git"
+UPSTREAM_URL = "https://github.com/kubernetes-sigs/image-builder.git"
+
+
+@dataclass
+class Args:
+    """
+    The arguments related to Git operations.
+    """
+
+    target_dir: Optional[str]
+    ssh_key_path: str
+    push_to_github: bool
+    _is_tmp_dir: bool = False
+
+
+def populate_temp_dir(arg: Args) -> Args:
+    """
+    Creates a temporary directory if one is not provided and ensures
+    the target directory exists.
+    """
+    if arg.target_dir is None:
+        arg._is_tmp_dir = True
+        arg.target_dir = mkdtemp()
+        print(f"Using temporary directory: {arg.target_dir}")
+
+    target_dir = Path(arg.target_dir)
+    if not target_dir.exists():
+        target_dir.mkdir()
+
+    return arg
+
+
+def clone_repo(args: Args) -> GitOps:
+    """
+    Clones the repo to the target directory.
+    """
+    args = populate_temp_dir(args)
+    ops = GitOps(Path(args.ssh_key_path))
+    ops.git_clone(K8S_FORK_URL, Path(args.target_dir))
+    return ops
+
+
+def update_repo(ops: GitOps):
+    """
+    Clones and rebases the repo to sync upstream updates.
+    """
+    ops.git_add_upstream(UPSTREAM_URL)
+    ops.git_fetch_upstream()
+    ops.git_rebase_upstream()
+
+
+def prepare_image_repo(args: Args):
+    """
+    Prepares the image repo for building, this includes cloning the repo and
+    rebasing it to sync with upstream changes.
+    """
+    ops = clone_repo(args)
+    update_repo(ops)

--- a/capi_image_builder/builder/image_ops.py
+++ b/capi_image_builder/builder/image_ops.py
@@ -1,0 +1,58 @@
+import os.path
+from dataclasses import dataclass
+from pathlib import Path
+import openstack.connection
+import semver as semver
+from openstack.image.v2.image import Image
+
+from builder.args import Args
+
+
+def get_image_version(output_file: Path) -> semver.VersionInfo:
+    filename = output_file.name
+    if "ubuntu" not in filename:
+        raise RuntimeError("Expected image filename to contain 'ubuntu'.")
+
+    if "kube" not in filename:
+        raise RuntimeError("Expected image filename to contain 'kube'.")
+
+    # Split the filename on "kube-v" to get the version number after
+    split_name = filename.split("kube-v")
+    if len(split_name) != 2:
+        raise RuntimeError("Expected image filename to contain 'kube-v'.")
+
+    version = split_name[1]
+    return semver.VersionInfo.parse(version)
+
+
+@dataclass
+class ImageDetails:
+    kube_version: semver.VersionInfo
+    image_path: Path
+    is_public: bool
+    os_version: str
+
+
+def upload_output_image(image_details: ImageDetails) -> Image:
+    conn = openstack.connect("openstack")
+    return conn.image.create_image(
+        name=f"capi-ubuntu-{image_details.os_version}-kube-v{image_details.kube_version}",
+        filename=image_details.image_path.as_posix(),
+        disk_format="qcow2",
+        container_format="bare",
+        visibility="public" if image_details.is_public else "private",
+    )
+
+
+def push_new_image(image_path: Path, args: Args) -> Image:
+    """
+    Build a new image using Packer and returns the resulting image name
+    """
+    image_version = get_image_version(image_path)
+    image_details = ImageDetails(
+        kube_version=image_version,
+        image_path=image_path,
+        is_public=args.make_image_public,
+        os_version=args.os_version,
+    )
+    return upload_output_image(image_details)

--- a/capi_image_builder/builder/image_ops.py
+++ b/capi_image_builder/builder/image_ops.py
@@ -1,6 +1,6 @@
-import os.path
 from dataclasses import dataclass
 from pathlib import Path
+
 import openstack.connection
 import semver as semver
 from openstack.image.v2.image import Image

--- a/capi_image_builder/builder/packer.py
+++ b/capi_image_builder/builder/packer.py
@@ -47,6 +47,10 @@ def run_packer_build(packer_dir: Path, ubuntu_version: str):
 
 
 def get_image_path(packer_dir: Path) -> Path:
+    """
+    Returns the path to the image file that was built from
+    the CAPI packer directory
+    """
     output_dir = packer_dir / "output"
     output_files = [file for file in output_dir.rglob("*") if file.is_file()]
 

--- a/capi_image_builder/builder/packer.py
+++ b/capi_image_builder/builder/packer.py
@@ -1,9 +1,15 @@
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
 # Relative dir of STFC vars from capi dir
 PACKER_VARS_FILE = "packer/config/stfc.json"
+
+
+def get_packer_dir_from_repo_root(repo_root: Path) -> Path:
+    """Get the path to the packer dir from the repo root."""
+    return repo_root / "images" / "capi"
 
 
 def prepare_env(packer_dir: Path) -> dict:
@@ -35,3 +41,9 @@ def run_packer(packer_dir: Path, ubuntu_version: str):
 
         if proc.returncode != 0:
             raise RuntimeError("Packer build failed")
+
+
+def clear_output_directory(packer_dir: Path):
+    output_dir = packer_dir / "output"
+    if output_dir.exists():
+        shutil.rmtree(output_dir)

--- a/capi_image_builder/builder/packer.py
+++ b/capi_image_builder/builder/packer.py
@@ -22,7 +22,7 @@ def prepare_env(packer_dir: Path) -> dict:
     return current_env
 
 
-def run_packer(packer_dir: Path, ubuntu_version: str):
+def run_packer_build(packer_dir: Path, ubuntu_version: str):
     """Run packer to build a target."""
     with subprocess.Popen(
         ["make", f"build-qemu-ubuntu-{ubuntu_version}"],
@@ -41,6 +41,13 @@ def run_packer(packer_dir: Path, ubuntu_version: str):
 
         if proc.returncode != 0:
             raise RuntimeError("Packer build failed")
+
+
+def build_image(repo_root: Path, ubuntu_version: str):
+    """Builds an update image"""
+    packer_dir = get_packer_dir_from_repo_root(repo_root)
+    clear_output_directory(packer_dir)
+    run_packer_build(packer_dir, ubuntu_version)
 
 
 def clear_output_directory(packer_dir: Path):

--- a/capi_image_builder/builder/packer.py
+++ b/capi_image_builder/builder/packer.py
@@ -26,6 +26,7 @@ def prepare_env(packer_dir: Path) -> dict:
 
 def run_packer_build(packer_dir: Path, ubuntu_version: str):
     """Run packer to build a target."""
+    print(f"Running packer build in {packer_dir}...")
     with subprocess.Popen(
         ["make", f"build-qemu-ubuntu-{ubuntu_version}"],
         cwd=packer_dir,

--- a/capi_image_builder/main.py
+++ b/capi_image_builder/main.py
@@ -42,6 +42,11 @@ def _parse_args() -> Args:
 
 
 def main(args: Args):
+    """
+    The main entry point for the program.
+    Clones, rebases and builds a new image then
+    uploads it to OpenStack and (optionally) pushes the changes to Github.
+    """
     prepare_image_repo(args)
     # Hardcode the Ubuntu version for now
     image_path = build_image(args)

--- a/capi_image_builder/main.py
+++ b/capi_image_builder/main.py
@@ -1,16 +1,10 @@
-# Clone repo
-# Rebase
-# Remove old files
-# Build
-# Push to OpenStack
-# Push to GitHub with new tag
+# TODO Push to GitHub with new tag
 import argparse
-from pathlib import Path
 
-from builder.git_steps import prepare_image_repo
 from builder.args import Args
+from builder.git_steps import prepare_image_repo
 from builder.image_ops import push_new_image
-from builder.packer import run_packer_build, build_image
+from builder.packer import build_image
 
 
 def _parse_args() -> Args:

--- a/capi_image_builder/main.py
+++ b/capi_image_builder/main.py
@@ -4,3 +4,34 @@
 # Build
 # Push to OpenStack
 # Push to GitHub with new tag
+import argparse
+from builder.git_steps import Args, prepare_image_repo
+
+
+def _parse_args() -> Args:
+    parser = argparse.ArgumentParser(
+        prog="CapiImageBuilder",
+        description="Builds images for use with CAPI, publishes them to OpenStack"
+        "and updates the repo on Github.",
+    )
+
+    parser.add_argument("ssh_key_path", help="The path to the SSH key to use.")
+    parser.add_argument(
+        "--target-dir",
+        help="The directory to clone the repo to."
+        "If not set this will use a temporary directory.",
+    )
+    parser.add_argument(
+        "--push-to-github", action="store_true", help="Push the new image to Github."
+    )
+
+    args = parser.parse_args()
+    return Args(**vars(args))
+
+
+def main(args: Args):
+    prepare_image_repo(args)
+
+
+if __name__ == "__main__":
+    main(_parse_args())

--- a/capi_image_builder/main.py
+++ b/capi_image_builder/main.py
@@ -5,7 +5,12 @@
 # Push to OpenStack
 # Push to GitHub with new tag
 import argparse
-from builder.git_steps import Args, prepare_image_repo
+from pathlib import Path
+
+from builder.git_steps import prepare_image_repo
+from builder.args import Args
+from builder.image_ops import push_new_image
+from builder.packer import run_packer_build, build_image
 
 
 def _parse_args() -> Args:
@@ -31,6 +36,10 @@ def _parse_args() -> Args:
 
 def main(args: Args):
     prepare_image_repo(args)
+    # Hardcode the Ubuntu version for now
+    image_path = build_image(args)
+    openstack_image = push_new_image(image_path, args)
+    print(openstack_image)
 
 
 if __name__ == "__main__":

--- a/capi_image_builder/main.py
+++ b/capi_image_builder/main.py
@@ -1,4 +1,5 @@
 # TODO Push to GitHub with new tag
+# TODO cleanup the temporary directory
 import argparse
 
 from builder.args import Args
@@ -21,7 +22,19 @@ def _parse_args() -> Args:
         "If not set this will use a temporary directory.",
     )
     parser.add_argument(
-        "--push-to-github", action="store_true", help="Push the new image to Github."
+        "--push-to-github",
+        action="store_true",
+        help="Push the new image to Github. Default: False",
+    )
+    parser.add_argument(
+        "--make_image_public",
+        action="store_true",
+        help="Make the new image public. Default: False",
+    )
+    parser.add_argument(
+        "--os_version",
+        default="2004",
+        help="The Ubuntu version to build. Default: 2004",
     )
 
     args = parser.parse_args()

--- a/capi_image_builder/requirements.txt
+++ b/capi_image_builder/requirements.txt
@@ -1,3 +1,5 @@
 gitpython
+semver
 pytest
 pylint
+openstacksdk

--- a/capi_image_builder/test/test_git_ops.py
+++ b/capi_image_builder/test/test_git_ops.py
@@ -12,14 +12,22 @@ UPSTREAM_URL = "https://github.com/kubernetes-sigs/image-builder.git"
 
 
 def test_git_clone_validates_protocol_ssh():
+    """
+    Test that the git clone method validates the protocol is
+    only SSH, so that we can later push to the repo.
+    """
     with pytest.raises(ValueError):
         GitOps(ssh_key_path=Path("/tmp/id_rsa")).git_clone(
-            "https://example.com", "/tmp/target"
+            "https://example.com", Path("/tmp/target")
         )
 
 
 @patch("builder.git_ops.Repo.clone_from")
 def test_git_clone_ssh(clone):
+    """
+    Test that the git clone method is called with the correct
+    arguments.
+    """
     keypair_mock = mock.NonCallableMock()
     expected_url = mock.NonCallableMock()
     expected_dir = mock.NonCallableMock()
@@ -35,6 +43,9 @@ def test_git_clone_ssh(clone):
 
 
 def test_git_set_username():
+    """
+    Test that the git username is set correctly.
+    """
     ops = GitOps(ssh_key_path=Path("/tmp/id_rsa"))
     ops.repo = mock.Mock()
 
@@ -47,6 +58,9 @@ def test_git_set_username():
 
 
 def test_git_set_email():
+    """
+    Test that the git email is set correctly.
+    """
     ops = GitOps(ssh_key_path=Path("/tmp/id_rsa"))
     ops.repo = mock.Mock()
 
@@ -60,6 +74,9 @@ def test_git_set_email():
 
 @pytest.fixture(scope="session")
 def _prepared_repo(tmp_path_factory) -> GitOps:
+    """
+    Fixture to return a pre-cloned repo for testing.
+    """
     path = tmp_path_factory.mktemp("git_env")
     ops = GitOps(ssh_key_path=Path("/tmp/id_rsa"))
 
@@ -71,6 +88,9 @@ def _prepared_repo(tmp_path_factory) -> GitOps:
 
 
 def test_git_upstream_add():
+    """
+    Tests that the correct upstream repo is added.
+    """
     ops = GitOps(ssh_key_path=Path("/tmp/id_rsa"))
     ops.repo = mock.MagicMock()
 
@@ -79,6 +99,9 @@ def test_git_upstream_add():
 
 
 def test_git_fetch_upstream_mock():
+    """
+    Tests that the fetch upstream method is called correctly.
+    """
     ops = GitOps(ssh_key_path=Path("/tmp/id_rsa"))
     # Patch fetch to not actually fetch
     ops.repo = mock.MagicMock()
@@ -88,6 +111,9 @@ def test_git_fetch_upstream_mock():
 
 
 def test_git_rebase_mock():
+    """
+    Tests that the rebase upstream method is called correctly.
+    """
     ops = GitOps(ssh_key_path=Path("/tmp/id_rsa"))
     # Patch rebase to not actually rebase
     ops.repo = mock.MagicMock()
@@ -97,6 +123,10 @@ def test_git_rebase_mock():
 
 
 def test_git_rebase_real(_prepared_repo):
+    """
+    Tests that the rebase upstream method is called correctly
+    using a real repo and the commit tree updates as expected.
+    """
     _prepared_repo.git_add_upstream(UPSTREAM_URL)
     assert "upstream" in _prepared_repo.repo.remotes
 
@@ -105,7 +135,7 @@ def test_git_rebase_real(_prepared_repo):
 
     # dfbd4fc1dbb2ee1808b17a8fb4d0a5b03417fb5a
     # is the next merge commit upstream, so this should be
-    # present after the rebase
+    # present after the rebase but not before.
     with pytest.raises(GitCommandError):
         _prepared_repo.repo.git.branch(
             "--contains", "dfbd4fc1dbb2ee1808b17a8fb4d0a5b03417fb5a"

--- a/capi_image_builder/test/test_git_ops.py
+++ b/capi_image_builder/test/test_git_ops.py
@@ -130,7 +130,8 @@ def test_git_rebase_real(_prepared_repo):
     _prepared_repo.git_add_upstream(UPSTREAM_URL)
     assert "upstream" in _prepared_repo.repo.remotes
 
-    # Manually checkout to a known starting commit to rebase from
+    # Manually checkout to a known starting commit to rebase
+    # from our image builder fork.
     _prepared_repo.repo.git.checkout("8e2d88942e66afc89aeb21e5e27e562f184fc08d")
 
     # dfbd4fc1dbb2ee1808b17a8fb4d0a5b03417fb5a

--- a/capi_image_builder/test/test_git_steps.py
+++ b/capi_image_builder/test/test_git_steps.py
@@ -3,7 +3,6 @@ from unittest.mock import patch, Mock, call, create_autospec, NonCallableMock
 
 from builder.git_ops import GitOps
 from builder.git_steps import (
-    Args,
     populate_temp_dir,
     clone_repo,
     K8S_FORK_URL,
@@ -11,6 +10,7 @@ from builder.git_steps import (
     UPSTREAM_URL,
     prepare_image_repo,
 )
+from builder.args import Args
 
 
 def test_new_temp_directory_generated():

--- a/capi_image_builder/test/test_git_steps.py
+++ b/capi_image_builder/test/test_git_steps.py
@@ -14,15 +14,22 @@ from builder.git_steps import (
 
 
 def test_new_temp_directory_generated():
+    """
+    Test that a new temporary directory is generated if one is not provided.
+    """
     args = Args(target_dir=None, ssh_key_path="test", push_to_github=False)
     args = populate_temp_dir(args)
 
     assert args.target_dir is not None
-    assert args._is_tmp_dir
+    assert args.is_tmp_dir
     Path(args.target_dir).exists()
 
 
 def test_existing_path_not_overwritten(tmp_path):
+    """
+    Test that an existing path is not overwritten and the
+    destination directory is created.
+    """
     expected_dir = tmp_path / "existing_path"
     args = Args(
         target_dir=expected_dir.as_posix(), ssh_key_path="test", push_to_github=False
@@ -30,7 +37,7 @@ def test_existing_path_not_overwritten(tmp_path):
 
     assert not expected_dir.exists()
     args = populate_temp_dir(args)
-    assert not args._is_tmp_dir
+    assert not args.is_tmp_dir
     assert args.target_dir == expected_dir.as_posix()
     assert expected_dir.exists()
 
@@ -76,6 +83,9 @@ def test_update_repo():
 
 
 def test_prepare_image_repo():
+    """
+    Test that the repo is cloned and rebased as expected
+    """
     arg_mock = NonCallableMock()
     with patch("builder.git_steps.clone_repo") as clone_mock:
         with patch("builder.git_steps.update_repo") as update_mock:

--- a/capi_image_builder/test/test_git_steps.py
+++ b/capi_image_builder/test/test_git_steps.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from unittest.mock import patch, Mock, call, create_autospec, NonCallableMock
 
+from builder.args import Args
 from builder.git_ops import GitOps
 from builder.git_steps import (
     populate_temp_dir,
@@ -10,7 +11,6 @@ from builder.git_steps import (
     UPSTREAM_URL,
     prepare_image_repo,
 )
-from builder.args import Args
 
 
 def test_new_temp_directory_generated():

--- a/capi_image_builder/test/test_git_steps.py
+++ b/capi_image_builder/test/test_git_steps.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+from unittest.mock import patch, Mock, call, create_autospec, NonCallableMock
+
+from builder.git_ops import GitOps
+from builder.git_steps import (
+    Args,
+    populate_temp_dir,
+    clone_repo,
+    K8S_FORK_URL,
+    update_repo,
+    UPSTREAM_URL,
+    prepare_image_repo,
+)
+
+
+def test_new_temp_directory_generated():
+    args = Args(target_dir=None, ssh_key_path="test", push_to_github=False)
+    args = populate_temp_dir(args)
+
+    assert args.target_dir is not None
+    assert args._is_tmp_dir
+    Path(args.target_dir).exists()
+
+
+def test_existing_path_not_overwritten(tmp_path):
+    expected_dir = tmp_path / "existing_path"
+    args = Args(
+        target_dir=expected_dir.as_posix(), ssh_key_path="test", push_to_github=False
+    )
+
+    assert not expected_dir.exists()
+    args = populate_temp_dir(args)
+    assert not args._is_tmp_dir
+    assert args.target_dir == expected_dir.as_posix()
+    assert expected_dir.exists()
+
+
+@patch("builder.git_steps.GitOps")
+@patch("builder.git_steps.Path")
+def test_clone_repo(path_mock, git_ops):
+    """
+    Test that the repo is cloned to the target directory.
+    """
+    args = Mock()
+
+    with patch("builder.git_steps.populate_temp_dir") as populate_mock:
+        returned = clone_repo(args)
+        populate_mock.assert_called_once_with(args)
+        updated_args = populate_mock.return_value
+
+    assert returned == git_ops.return_value
+    git_ops.assert_called_once_with(path_mock.return_value)
+    ops_class = git_ops.return_value
+
+    # Clone
+    ops_class.git_clone.assert_called_once_with(K8S_FORK_URL, path_mock.return_value)
+
+    path_mock.assert_has_calls(
+        [call(updated_args.ssh_key_path), call(updated_args.target_dir)]
+    )
+
+
+def test_update_repo():
+    """
+    Test that the repo is updated with the upstream fork.
+    """
+    ops = create_autospec(GitOps)
+    update_repo(ops)
+    ops.git_add_upstream.assert_called_once_with(UPSTREAM_URL)
+    ops.git_fetch_upstream.assert_called_once_with()
+    ops.git_rebase_upstream.assert_called_once_with()
+
+    # These should be pre-set on the system
+    ops.set_git_username.assert_not_called()
+    ops.set_git_email.assert_not_called()
+
+
+def test_prepare_image_repo():
+    arg_mock = NonCallableMock()
+    with patch("builder.git_steps.clone_repo") as clone_mock:
+        with patch("builder.git_steps.update_repo") as update_mock:
+            prepare_image_repo(arg_mock)
+
+    clone_mock.assert_called_once_with(arg_mock)
+    update_mock.assert_called_once_with(clone_mock.return_value)

--- a/capi_image_builder/test/test_image_ops.py
+++ b/capi_image_builder/test/test_image_ops.py
@@ -1,0 +1,94 @@
+from unittest.mock import patch, NonCallableMock
+
+import pytest
+import semver
+
+from builder.image_ops import (
+    get_image_version,
+    upload_output_image,
+    ImageDetails,
+    push_new_image,
+)
+
+
+def test_get_image_version(tmp_path):
+    expected_version = semver.VersionInfo(major=1, minor=2, patch=3)
+    output_file = tmp_path / "ubuntu-2004-kube-v1.2.3"
+    output_file.touch()
+
+    assert get_image_version(output_file) == expected_version
+
+
+def test_get_image_version_missing_ubuntu(tmp_path):
+    output_file = tmp_path / "rhel-8-kube-v1.2.3"
+    output_file.touch()
+
+    with pytest.raises(RuntimeError) as error:
+        get_image_version(output_file)
+
+    assert "Expected image filename to contain 'ubuntu'" in str(error.value)
+
+
+def test_get_image_version_missing_kube(tmp_path):
+    output_file = tmp_path / "ubuntu-2004-v1.2.3"
+    output_file.touch()
+
+    with pytest.raises(RuntimeError) as error:
+        get_image_version(output_file)
+
+    assert "Expected image filename to contain 'kube'" in str(error.value)
+
+
+@patch("builder.image_ops.openstack")
+def test_upload_image(mock_openstack, tmp_path):
+    """
+    Test that the upload_image function triggers Openstack correctly
+    """
+    details = ImageDetails(
+        kube_version=semver.VersionInfo(major=1, minor=2, patch=3),
+        os_version="2004",
+        image_path=tmp_path / "example_image",
+        is_public=False,
+    )
+
+    for visibility in [True, False]:
+        expected = "public" if visibility else "private"
+
+        mock_openstack.reset_mock()
+        upload_output_image(details)
+
+        mock_openstack.connect.assert_called_once_with("openstack")
+        conn = mock_openstack.connect.return_value
+        conn.image.create_image.assert_called_once_with(
+            name="capi-ubuntu-2004-kube-v1.2.3",
+            filename=details.image_path.as_posix(),
+            disk_format="qcow2",
+            container_format="bare",
+            visibility="private",
+        )
+
+
+def test_push_new_image():
+    """
+    Test that the push_new_image function builds and
+    pushes the correct image
+    """
+    image_path = NonCallableMock()
+    args = NonCallableMock()
+
+    with patch("builder.image_ops.get_image_version") as get_image_version, patch(
+        "builder.image_ops.upload_output_image"
+    ) as upload_output_image:
+
+        image = push_new_image(image_path, args)
+
+    get_image_version.assert_called_once_with(image_path)
+    upload_output_image.assert_called_once_with(
+        ImageDetails(
+            kube_version=get_image_version.return_value,
+            os_version=args.os_version,
+            image_path=image_path,
+            is_public=args.make_image_public,
+        )
+    )
+    assert image == upload_output_image.return_value

--- a/capi_image_builder/test/test_main.py
+++ b/capi_image_builder/test/test_main.py
@@ -1,11 +1,18 @@
+from pathlib import Path
 from unittest.mock import patch, NonCallableMock
 
 from main import main
 
 
-@patch("main.prepare_image_repo")
-def test_main(image_prep):
+def test_main(tmp_path):
     args = NonCallableMock()
-    main(args)
+    args.target_dir = tmp_path.as_posix()
+
+    with patch("main.prepare_image_repo") as image_prep, patch(
+        "main.build_image"
+    ) as build_image, patch("main.push_new_image") as push_image:
+        main(args)
 
     image_prep.assert_called_once_with(args)
+    build_image.assert_called_once_with(args)
+    push_image.assert_called_once_with(build_image.return_value, args)

--- a/capi_image_builder/test/test_main.py
+++ b/capi_image_builder/test/test_main.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from unittest.mock import patch, NonCallableMock
 
 from main import main

--- a/capi_image_builder/test/test_main.py
+++ b/capi_image_builder/test/test_main.py
@@ -4,6 +4,9 @@ from main import main
 
 
 def test_main(tmp_path):
+    """
+    Tests the main steps, which consist of very high level goals.
+    """
     args = NonCallableMock()
     args.target_dir = tmp_path.as_posix()
 

--- a/capi_image_builder/test/test_main.py
+++ b/capi_image_builder/test/test_main.py
@@ -1,0 +1,11 @@
+from unittest.mock import patch, NonCallableMock
+
+from main import main
+
+
+@patch("main.prepare_image_repo")
+def test_main(image_prep):
+    args = NonCallableMock()
+    main(args)
+
+    image_prep.assert_called_once_with(args)

--- a/capi_image_builder/test/test_packer.py
+++ b/capi_image_builder/test/test_packer.py
@@ -127,9 +127,9 @@ def test_get_image_path(tmp_path):
     output_subdir.mkdir()
 
     output_file = output_subdir / "ubuntu-2004-kube-v1.23.10"
-    with open(output_file, "wb") as f:
+    with open(output_file, "wb") as file_handle:
         # 1GB file to pass the size check
-        f.truncate(1024 * 1024 * 1024)
+        file_handle.truncate(1024 * 1024 * 1024)
 
     assert get_image_path(tmp_path) == output_file
 
@@ -164,9 +164,9 @@ def test_get_image_path_small_file(tmp_path):
     output_subdir.mkdir()
 
     output_file = output_subdir / "ubuntu-2004-kube-v1.23.10"
-    with open(output_file, "wb") as f:
+    with open(output_file, "wb") as file_handle:
         # 1GB - 1 byte file to fail the size check
-        f.truncate(1024 * 1024 * 1024 - 1)
+        file_handle.truncate(1024 * 1024 * 1024 - 1)
 
     with pytest.raises(RuntimeError) as error:
         get_image_path(tmp_path)

--- a/capi_image_builder/test/test_packer.py
+++ b/capi_image_builder/test/test_packer.py
@@ -3,7 +3,23 @@ from unittest.mock import patch, ANY
 
 import pytest
 
-from builder.packer import prepare_env, run_packer
+from builder.packer import (
+    prepare_env,
+    run_packer,
+    get_packer_dir_from_repo_root,
+    clear_output_directory,
+)
+
+
+def test_get_packer_dir_from_repo_root(tmp_path):
+    """
+    Test that the get_packer_dir_from_repo_root function returns the
+    correct path.
+    """
+    repo_root = tmp_path / "repo_root"
+    packer_dir = repo_root / "images" / "capi"
+
+    assert get_packer_dir_from_repo_root(repo_root) == packer_dir
 
 
 def test_prepare_env():
@@ -73,3 +89,27 @@ def test_run_packer_error(mock_popen):
     )
 
     proc.wait.assert_called_once_with()
+
+
+def test_clear_output_directory(tmp_path):
+    """
+    Test that the clear_output_directory function deletes all files
+    from the output directory.
+    """
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    fake_ubuntu_paths = [
+        output_dir / "ubuntu-2004-kube-v1.23.10",
+        output_dir / "ubuntu-2004-kube-v1.24.99",
+        output_dir / "other-arch",
+    ]
+
+    for path in fake_ubuntu_paths:
+        path.mkdir()
+
+    clear_output_directory(tmp_path)
+
+    for path in fake_ubuntu_paths:
+        assert not path.exists()
+    assert not output_dir.exists()


### PR DESCRIPTION
- Wires the various steps together
- Adds directory handling
- Openstack steps to upload the image
- Associated tests

We still need to (in a future PR):
- Cleanup a tmp directory if a user specified one
- Push the rebased repo to Github on completion

To test:
Setup a `clouds.yaml` file with the `openstack` cloud, such that `openstack --os-cloud openstack server list` returns something sane

```bash
cd SCD-Openstack-Utils/capi_image_builder
python3 -m venv venv 
source venv/bin/activate
python3 -m pip install requirements.txt
python3 main.py ~/.ssh/id_rsa.pub
# Grab a coffee
```

Note this requires us to use a pub key system so we can later upload the image (not implemented as of this PR)