### PR TITLE
CI and CD improvements

### DIFF
--- a/.github/workflows/capi_image_build.yaml
+++ b/.github/workflows/capi_image_build.yaml
@@ -1,6 +1,13 @@
 name: K8s Cluster API PR
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - ".github/workflows/capi_image_build.yaml"
+      - "capi_image_builder/**"
 
 jobs:
   test_and_lint:

--- a/.github/workflows/rabbit_consumer.yaml
+++ b/.github/workflows/rabbit_consumer.yaml
@@ -1,6 +1,13 @@
 name: Rabbit Consumer
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - ".github/workflows/rabbit_consumer.yaml"
+      - "OpenStack-Rabbit-Consumer/**"
 
 jobs:
   test_and_lint:


### PR DESCRIPTION
This changes the CI and CD workflows to only run on changed code, not
everything (except the formatter which is fast).

Against master it will always build everything for sanity.
