### PR TITLE
Use Hashcat and Phoronix to benchmark

### DIFF
--- a/gpu_benchmark/gpu_setup.sh
+++ b/gpu_benchmark/gpu_setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+sudo dnf update -y
+
+# # Nvidia drivers - centos8
+echo 'blacklist nouveau
+options nouveau modeset=0' > /usr/lib/modprobe.d/blacklist-nouveau.conf
+echo "Updating dracut"
+sudo dracut --force
+(lsmod | grep -wq nouveau && echo "Rebooting to disable nouveau" && sudo reboot) || true
+
+sudo dnf install tar bzip2 make automake gcc gcc-c++ pciutils elfutils-libelf-devel libglvnd-devel -y
+sudo dnf install -y kernel-devel kernel-headers -y
+wget -nc https://developer.download.nvidia.com/compute/cuda/12.1.0/local_installers/cuda_12.1.0_530.30.02_linux.run
+nvidia-smi || sudo sh cuda_12.1.0_530.30.02_linux.run --silent
+nvidia-smi || (echo "Rebooting machine to load Nvidia Driver" && sudo reboot)

--- a/gpu_benchmark/power_perf.sh
+++ b/gpu_benchmark/power_perf.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+nvidia-smi || bash "$DIR/gpu_setup.sh"
+
+sudo dnf install hashcat ipmitool -y
+wget -nc https://github.com/brannondorsey/naive-hashcat/releases/download/data/rockyou.txt
+wget -nc https://github.com/stealthsploit/OneRuleToRuleThemStill/raw/main/OneRuleToRuleThemStill.rule
+
+rm hashes.txt -f || true
+
+# This was generated with the following commands
+# echo -n "password" | openssl passwd -1 -stdin > hashes.txt
+# echo -n "easyPassword" | openssl passwd -1 -stdin >> hashes.txt
+# echo -n "myTest" | openssl passwd -1 -stdin >> hashes.txt
+# echo -n "horseBattery" | openssl passwd -1 -stdin >> hashes.txt
+
+# The dollar signs are related to the hash type, not a bash var. Disable the warning.
+# shellcheck disable=SC2016
+echo '$1$2by6iYgn$Cxfi5SDsfe7Z8GlfkNfyO0
+$1$oeDRzC8s$xUyo21SnMLoba.JYX0qtC/
+$1$/QMqw7pS$EfbzB7uf3taxeIHs1r.NM1
+$1$CMp0jii5$XQubg6JNBOC9y6bxuU7NZ/
+$1$IuWNtsUB$Nmub4MHpC2n2KZ0ESkg9E0' > hashes.txt
+
+echo "Hashcat is capturing to hashcat.log"
+/usr/bin/time -f %e hashcat -a 0 -m 500 hashes.txt rockyou.txt -r OneRuleToRuleThemStill.rule -O -w 3 --potfile-disable > hashcat.log 2>&1 &
+
+rm -f power.log && nvidia-smi > power.log
+i=0
+while pgrep hashcat; do
+  echo "Minute $i" | tee -a power.log
+  ipmitool dcmi power reading | tee -a power.log
+  sleep 60
+done
+
+echo "Finished capturing power"

--- a/gpu_benchmark/readme.md
+++ b/gpu_benchmark/readme.md
@@ -15,13 +15,19 @@ Requirements
 ------------
 
 - Rocky Linux 8.x Machine
-- GPU with CUDA support  (Note: We have selected PyTorch for the ability to run OpenCL in the future)
+- GPU with CUDA support  (Note: We have selected Phoronix Test Suite as we can switch to OpenCL in the future)
 - Internet access
-- 64GB+ of RAM. (Where the RAM Disk takes 40GB).
+
+Scripts
+-------
+
+- gpu_benchmark.sh - Script to run the benchmark. This benchmarks card #0 by default using the Phoronix Test Suite and will output a file gpu-benchmark.txt in the current directory.
+- power_perf.sh - Script to capture power data from IPMI whilst running hashcat on preset known easy passwords. It requires a physical host for ipmitool to work. It will output a file power.log in the current directory every minute.
 
 Usage
 -----
-sudo ./gpu_benchmark.sh [-n <number of GPUs>]
+sudo ./gpu_benchmark.sh [-n <number of test iterations>]
+sudo ./power_perf.sh
 
-Results will be stored in ~/results as *.txt files, where the number corresponds to the number of GPUs used.
-Log files from the training runs are stored in ~/results/*.logs files.
+cat gpu-benchmark.txt
+cat power.log

--- a/gpu_benchmark/readme.md
+++ b/gpu_benchmark/readme.md
@@ -2,14 +2,10 @@ GPU Benchmarking Script
 =======================
 
 This script is used to benchmark the GPU performance of a machine. It is
-based on the SciML Benchmarking suite, which can be found here:
-https://github.com/stfc-sciml/sciml-bench . (Our thanks to the SciML team).
+based on the Phoronix Test Suite and will run a number of benchmarks automatically.
 
 The script is designed to be run on a machine with a GPU, and will
 run with the specified number of GPUs (default 1).
-
-THe underlying benchmarking tool is PyTorch. The script will install
-PyTorch and the SciML Benchmarking suite and required drivers automatically.
 
 Requirements
 ------------
@@ -31,3 +27,26 @@ sudo ./power_perf.sh
 
 cat gpu-benchmark.txt
 cat power.log
+
+Benchmark Description
+---------------------
+
+The benchmarks run are:
+
+- fahbench https://openbenchmarking.org/test/pts/fahbench
+
+- realsr-ncnn https://openbenchmarking.org/test/pts/realsr-ncnn
+
+- octanebench https://openbenchmarking.org/test/pts/octanebench
+
+These represent a variety of workloads, with tests that place substantial load on the higher class compute GPUs.
+
+Scoring
+-------
+
+Separately to this tool, we normalise the scores to ensure they use a similar scoring scale to fahbench and octanebench, as follows:
+
+realsr-ncnn (TAA: N): 1000 / seconds
+realsr-ncnn (TAA: Y): 10000 / seconds
+
+These FAH and Octane benchmark scores are then combined to give a final score for each GPU.


### PR DESCRIPTION
The previous implementation was IO bound on higher performance cards. Instead we switch to:

Phoronix Test Suite - This runs per card benchmarks and outputs the total run time

Hashcat - This acts as a stress test and captures power data