### PR TITLE
Release Multiple RPM Versions

### DIFF
--- a/.github/workflows/iriscast_package_build.yaml
+++ b/.github/workflows/iriscast_package_build.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           cd iriscasttools && pylint --recursive yes test iriscasttools
 
-  build:
+  build-wheel:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -47,20 +47,50 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
+      - name: Get Package Version
+        id: version
+        run: echo "version=$(python iriscasttools/setup.py --version)" >> $GITHUB_ENV
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+      - name: Build Wheels
+        run: cd iriscasttools && python setup.py bdist_wheel
+      - name: Upload Wheel
+        uses: actions/upload-artifact@v3
+        with:
+          name: iriscasttools-${{ env.version }}-py3-none-any.whl
+          path: iriscasttools/dist/iriscasttools-${{ env.version }}-py3-none-any.whl
+          if-no-files-found: error
 
+  build-rpms:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ["3.x", "3.10", "3.6"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+      - name: Get Package Version
+        id: version
+        run: echo "version=$(python iriscasttools/setup.py --version)" >> $GITHUB_ENV
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y rpm
-          python -m pip install --upgrade pip
-          pip install setuptools wheel
-
-      - name: Build RPM and Wheels
-        run: cd iriscasttools && python setup.py bdist_wheel bdist_rpm
-
+      - name: Build RPM
+        run: |
+          cd iriscasttools
+          python setup.py bdist_rpm
+          cd dist
+          mv iriscasttools-${{ env.version }}-1.noarch.rpm iriscasttools-${{ env.version }}-py${{ matrix.python-version }}.noarch.rpm
       - uses: actions/upload-artifact@v3
         with:
-          name: iriscasttools
-          path: iriscasttools/dist
+          name: iriscasttools-${{ env.version }}-py${{ matrix.python-version }}.noarch.rpm
+          path: iriscasttools/dist/iriscasttools-${{ env.version }}-py${{ matrix.python-version }}.noarch.rpm
           if-no-files-found: error
 
   publish:
@@ -68,7 +98,8 @@ jobs:
     if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     needs:
       - test_and_lint
-      - build
+      - build-wheel
+      - build-rpms
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -80,22 +111,22 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Download Wheels
-        id: download
-        uses: actions/download-artifact@v3
-        with:
-          name: iriscasttools
-          path: iriscasttools/dist
-
       - name: Get Package Version
         id: version
         run: echo "version=$(python iriscasttools/setup.py --version)" >> $GITHUB_ENV
 
+      - name: Download Artifacts
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          path: iriscasttools/dist
+
       - name: Make Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: iriscasttools/dist/*
+          artifacts: iriscasttools/dist/*/*
           tag: ${{ env.version }}
           name: iriscasttools-${{ env.version }}
           skipIfReleaseExists: true
+
 


### PR DESCRIPTION
separate out building rpms and wheel as two distinct steps - build multiple RPMs for different python versions 
- most notably python3.6 which is required for package to work on HVs

Previous PR #61 built RPM against python 3.11 - which doesn't work on HVs 
