### PR TITLE
build RPM for 3.6.8 instead of 3.6.15

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -6,7 +6,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Rabbit Consumer
         uses: psf/black@stable
         with:

--- a/.github/workflows/iriscast_package_build.yaml
+++ b/.github/workflows/iriscast_package_build.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.x", "3.10", "3.6"]
+        python-version: ["3.x", "3.10", "3.6.8"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.x", "3.10", "3.6"]
+        python-version: ["3.x", "3.10", "3.6.8"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
quick fix - sub-versions didn't match for python 3.6 RPM in #62 
