### PR TITLE
Bump chart to point to new rabbit consumers

### DIFF
--- a/charts/rabbit-consumer/Chart.yaml
+++ b/charts/rabbit-consumer/Chart.yaml
@@ -6,10 +6,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.0.2"
+appVersion: "v2.0.0"


### PR DESCRIPTION
Bumps the chart to point to the new rabbit consumer version "upstream" changes