### PR TITLE
Add DNS Entry Checker

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -21,3 +21,8 @@ jobs:
         uses: psf/black@stable
         with:
           src: "iriscasttools/iriscasttools"
+          
+      - name: DNS Entry Checker 
+        uses: psf/black@stable
+        with:
+            src: "DNSEntryChecker"

--- a/.github/workflows/dns_entry_checker.yaml
+++ b/.github/workflows/dns_entry_checker.yaml
@@ -1,0 +1,33 @@
+name: DNS Entry Checker Unittest
+
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
+    paths:
+      - "DNSEntryChecker/**"
+      - ".github/workflows/dns_entry_checker.yaml"
+
+jobs:
+  test_and_lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r DNSEntryChecker/requirements.txt
+      - name: Test with unittest
+        run: |
+            cd DNSEntryChecker
+            python3 -m unittest discover -s ./test -p "test_*.py"

--- a/DNSEntryChecker/dns_entry_checker.py
+++ b/DNSEntryChecker/dns_entry_checker.py
@@ -1,0 +1,114 @@
+import paramiko
+from re import compile
+from getpass import getpass
+from collections import defaultdict
+
+
+# Creates an SSH client through Paramiko with the users details and returns the client
+def create_client(host, user, password):
+    client = paramiko.client.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy)
+    client.connect(hostname=host, username=user, password=password, timeout=60)
+    return client
+
+
+# Executes a command through a Paramiko client, waits for an exit status and outputs the response
+def ssh_command(client, command):
+    _stdin, _stdout, _stderr = client.exec_command(command, get_pty=True, timeout=60)
+    _stdout.channel.recv_exit_status()
+    return _stdout.readlines()
+
+
+# Checks if the IP address and DNS match
+def pair_ip_and_dns(dns_pair, order_check_dict, ip_rexp):
+    last_rexp = compile(r"([0-9]{1,3}\.[0-9]{1,3}(?!.))")
+
+    ips = ip_rexp.findall(dns_pair)
+    ips = ([ips[0][0], ips[1][0]])
+
+    order_values = last_rexp.findall(ips[1])[0].split(".")
+    order_check_dict[order_values[0]].append(order_values[1])
+    return ips
+
+
+# Checks if the DNS returns the matching IP
+def check_ip_dns_mismatch(ips, client, ip_rexp, backward_mismatch_file, forward_mismatch_file, backward_missing_file):
+    if ips[0].replace("-", ".") == ips[1]:
+        returned_dns = ssh_command(client, "dig -x {s} +short".format(s=ips[1]))
+        if returned_dns:
+            backward_ip = ip_rexp.findall(returned_dns[0])
+            if not backward_ip:
+                backward_missing_file.write(f"{ips[1]}\n")
+            elif not backward_ip[0][0] == ips[0]:
+                backward_mismatch_file.write(f"{ips[1]}\n")
+        else:
+            backward_missing_file.write(f"{ips[1]}\n")
+    else:
+        forward_mismatch_file.write(f"{ips[1]}\n")
+
+
+# Checks which IPs are missing from 2-254
+def check_missing_ips(key, gap_missing_file, i):
+    res = set([eval(j) for j in key[1]])
+    missing_values = [k for k in sorted(set(range(2, 255))) if k not in res]
+    for ip in missing_values:
+        gap_missing_file.write(f"172.16.{i + 100}.{ip}\n")
+
+
+def dns_entry_checker():
+    # Prompt the user for their FedID, Password and IP to connect to
+    user = input("FedID: ")
+    password = getpass("Password: ")
+    ip = input("IP: ")
+
+    # Create an SSH client with the credentials given
+    client = create_client(ip, user, password)
+
+    # Run a command on the VM to get all IP addresses with their domain names
+    dns_list = ssh_command(client, "dig @ns1.rl.ac.uk stfc.ac.uk  axfr | "
+                                   "grep -i nubes.stfc.ac.uk | "
+                                   "grep -v CNAME | "
+                                   "grep '172.16.105'")
+
+    # Create or clear, then open to append to, the output files
+    open("output\\forward_mismatch_list.txt", "w").close()
+    open("output\\backward_mismatch_list.txt", "w").close()
+    open("output\\forward_missing_list.txt", "w").close()
+    open("output\\backward_missing_list.txt", "w").close()
+    open("output\\gap_missing_list.txt", "w").close()
+    forward_mismatch_file = open("output\\forward_mismatch_list.txt", "a")
+    backward_mismatch_file = open("output\\backward_mismatch_list.txt", "a")
+    forward_missing_file = open("output\\forward_missing_list.txt", "a")
+    backward_missing_file = open("output\\backward_missing_list.txt", "a")
+    gap_missing_file = open("output\\gap_missing_list.txt", "a")
+
+    # Define the Regex used to identify IPs
+    ip_rexp = compile(r"(([0-9]{1,3}[.-]){3}[0-9]{1,3})")
+
+    # Create a dictionary to store IPs for checking gaps
+    order_check_dict = defaultdict(list)
+
+    # Check through all IP and DNS pairs received
+    for i, dns_pair in enumerate(dns_list):
+        print(i + 1, "/", len(dns_list))
+
+        ips = pair_ip_and_dns(dns_pair, order_check_dict, ip_rexp)
+
+        check_ip_dns_mismatch(ips, client, ip_rexp,
+                              backward_mismatch_file, forward_mismatch_file, backward_missing_file)
+
+    # Check through all IP addresses received for gaps
+    for i, key in enumerate(order_check_dict.items()):
+        check_missing_ips(key, gap_missing_file, i)
+
+    # Close the Client and output files
+    client.close()
+    forward_mismatch_file.close()
+    backward_mismatch_file.close()
+    forward_missing_file.close()
+    backward_missing_file.close()
+    gap_missing_file.close()
+
+
+if __name__ == '__main__':
+    dns_entry_checker()

--- a/DNSEntryChecker/requirements.txt
+++ b/DNSEntryChecker/requirements.txt
@@ -1,0 +1,2 @@
+paramiko~=2.12.0
+parameterized~=0.9.0

--- a/DNSEntryChecker/test/test_dns_entry_checker.py
+++ b/DNSEntryChecker/test/test_dns_entry_checker.py
@@ -1,0 +1,164 @@
+import unittest
+from re import compile
+from unittest.mock import MagicMock, patch, NonCallableMock
+from parameterized import parameterized
+from collections import defaultdict
+
+import dns_entry_checker
+from dns_entry_checker import (
+    create_client,
+    ssh_command,
+    pair_ip_and_dns,
+    check_ip_dns_mismatch,
+    check_missing_ips,
+)
+
+
+class DNSEntryCheckerTests(unittest.TestCase):
+    @patch("dns_entry_checker.paramiko")
+    def test_create_client(self, mock_paramiko):
+        host = "test.aquilon.gridpp.rl.ac.uk"
+        user = "test.abc12345"
+        password = "test.A4gdfGs"
+
+        mock_client = MagicMock()
+        mock_paramiko.client.SSHClient.return_value = mock_client
+        mock_paramiko.client.set_missing_host_key_policy = MagicMock()
+        mock_paramiko.AutoAddPolicy = NonCallableMock()
+        mock_paramiko.connect = MagicMock()
+
+        client = create_client(host, user, password)
+
+        client.connect.assert_called_once_with(
+            hostname=host, username=user, password=password, timeout=60
+        )
+
+        self.assertEqual(client, mock_client)
+
+    def test_ssh_command(self):
+        mock_client = MagicMock()
+        command = "test aq show_host --hostname localhost"
+
+        mock_stdout = MagicMock()
+        mock_client.exec_command.return_value = MagicMock(), mock_stdout, MagicMock()
+        mock_stdout.channel.recv_exit_status.return_value = NonCallableMock()
+        mock_stdout.readlines.return_value = NonCallableMock()
+
+        command_output = ssh_command(mock_client, command)
+
+        mock_client.exec_command.assert_called_once_with(
+            command, get_pty=True, timeout=60
+        )
+        mock_stdout.channel.recv_exit_status.assert_called_once()
+        mock_stdout.readlines.assert_called_once()
+
+        self.assertEqual(command_output, mock_stdout.readlines.return_value)
+
+    def test_pair_ip_and_dns(self):
+        dns_pair = "test-host-172-16-1-1.nubes.stfc.ac.uk 7200 IN A\t172.16.1.1\r\n"
+        order_check_dict = defaultdict(list)
+        ip_rexp = compile(r"(([0-9]{1,3}[.-]){3}[0-9]{1,3})")
+
+        command_output = pair_ip_and_dns(dns_pair, order_check_dict, ip_rexp)
+        self.assertEqual(command_output[0].replace('-', '.'), command_output[1])
+
+    @parameterized.expand(
+        [
+            ("IPs match", ["172-16-1-1", "172.16.1.1"], True),
+            ("IPs don't match", ["172-16-1-1", "172.16.1.0"], False),
+        ]
+    )
+    def test_check_ip_dns_mismatch(self, name, returned_ips, expected_out):
+        ips = returned_ips
+        client = MagicMock()
+        ip_rexp = compile(r"(([0-9]{1,3}[.-]){3}[0-9]{1,3})")
+        backward_mismatch_file = MagicMock()
+        forward_mismatch_file = MagicMock()
+        backward_missing_file = MagicMock()
+
+        with patch("dns_entry_checker.ssh_command"):
+            dns_entry_checker.ssh_command.return_value = []
+
+            check_ip_dns_mismatch(ips, client, ip_rexp, backward_mismatch_file, forward_mismatch_file,
+                                  backward_missing_file)
+
+        if expected_out:
+            forward_mismatch_file.write.assert_not_called()
+        else:
+            forward_mismatch_file.write.assert_called_once()
+
+    @parameterized.expand(
+        [
+            ("DNS returned", ["test-host-172-16-1-1.nubes.stfc.ac.uk"], True),
+            ("DNS not returned", [], False),
+        ]
+    )
+    def test_check_ip_dns_mismatch_dns_returned(self, name, returned_dns, expected_out):
+        ips = ["172-16-1-1", "172.16.1.1"]
+        client = MagicMock()
+        ip_rexp = compile(r"(([0-9]{1,3}[.-]){3}[0-9]{1,3})")
+        backward_mismatch_file = MagicMock()
+        forward_mismatch_file = MagicMock()
+        backward_missing_file = MagicMock()
+
+        with patch("dns_entry_checker.ssh_command"):
+            dns_entry_checker.ssh_command.return_value = returned_dns
+
+            check_ip_dns_mismatch(ips, client, ip_rexp, backward_mismatch_file, forward_mismatch_file,
+                                  backward_missing_file)
+
+        if not expected_out:
+            backward_missing_file.write.assert_called_once()
+        else:
+            backward_missing_file.write.asser_not_called()
+
+    @parameterized.expand(
+        [
+            ("Return doesn't contain IP", ["No IPS here"], 0),
+            ("Returned IP doesn't match", ["test-host-172-16-1-2.nubes.stfc.ac.uk"], 1),
+            ("Returned IP matches", ["test-host-172-16-1-1.nubes.stfc.ac.uk"], 2),
+        ]
+    )
+    def test_check_ip_dns_mismatch_backwards_not_found(self, name, returned_ips, expected_out):
+        ips = ["172-16-1-1", "172.16.1.1"]
+        client = MagicMock()
+        ip_rexp = compile(r"(([0-9]{1,3}[.-]){3}[0-9]{1,3})")
+        backward_mismatch_file = MagicMock()
+        forward_mismatch_file = MagicMock()
+        backward_missing_file = MagicMock()
+
+        with patch("dns_entry_checker.ssh_command"):
+            dns_entry_checker.ssh_command.return_value = returned_ips
+
+            check_ip_dns_mismatch(ips, client, ip_rexp, backward_mismatch_file, forward_mismatch_file,
+                                  backward_missing_file)
+
+        if expected_out == 0:
+            backward_missing_file.write.assert_called_once()
+        elif expected_out == 1:
+            backward_mismatch_file.write.assert_called_once()
+        else:
+            backward_mismatch_file.write.assert_not_called()
+            backward_missing_file.write.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("Gaps", [5], True),
+            ("No gaps", sorted(set(range(2, 255))), False),
+        ]
+    )
+    def test_check_missing_ips(self, name, ips, expected_out):
+        key = ("105", [str(x).zfill(0) for x in ips])
+        gap_missing_file = MagicMock()
+        i = 5
+
+        check_missing_ips(key, gap_missing_file, i)
+
+        if expected_out:
+            gap_missing_file.write.assert_called()
+        else:
+            gap_missing_file.write.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a script that checks for missing and mismatching IPs and their DNS' in order to more easily identify and investigate them.