### PR TITLE
Rabbit consumers - wait for sidecar

### DIFF
--- a/charts/rabbit-consumer/Chart.yaml
+++ b/charts/rabbit-consumer/Chart.yaml
@@ -6,11 +6,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.4
+version: 1.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "v2.3.4"
-

--- a/charts/rabbit-consumer/templates/deployment.yaml
+++ b/charts/rabbit-consumer/templates/deployment.yaml
@@ -28,6 +28,26 @@ spec:
             - configMapRef:
                 name: {{ .Release.Name }}-kerberos-env
 
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - klist -s
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - klist -s
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+
           volumeMounts:
             - name: entrypoints
               mountPath: /etc/entrypoints.d

--- a/charts/rabbit-consumer/templates/deployment.yaml
+++ b/charts/rabbit-consumer/templates/deployment.yaml
@@ -20,11 +20,31 @@ spec:
         app: rabbit-consumer
     spec:
       containers:
-        - name: consumer
+        - name: kerberos
+          image: "{{ .Values.kerberosSidecar.image.repository }}:{{ .Values.kerberosSidecar.image.tag }}"
+          command: ["/bin/sh", "-c", "/etc/entrypoints.d/sidecar-entrypoint.sh"]
+          imagePullPolicy: Always
+          envFrom:
+            - configMapRef:
+                name: {{ .Release.Name }}-kerberos-env
 
+          volumeMounts:
+            - name: entrypoints
+              mountPath: /etc/entrypoints.d
+            - name: shared
+              mountPath: /shared
+            # Kerberos related
+            - name: kerberos-conf-files
+              mountPath: /etc/krb5.conf
+              subPath: krb5.conf
+            - name: kerberos-keytab
+              mountPath: /etc/krb5.keytab
+              subPath: krb5.keytab
+              readOnly: true
+        
+        - name: consumer
           image: "{{ .Values.consumer.image.repository }}:{{ default .Chart.AppVersion .Values.consumer.image.tag }}"
           imagePullPolicy: {{ .Values.consumer.image.pullPolicy }}
-
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-consumer-env
@@ -43,29 +63,6 @@ spec:
               subPath: krb5.conf
             - name: trusted-certs
               mountPath: /etc/grid-security/certificates
-
-        - name: kerberos
-          image: "{{ .Values.kerberosSidecar.image.repository }}:{{ .Values.kerberosSidecar.image.tag }}"
-          command: ["/bin/sh", "-c", "/etc/entrypoints.d/sidecar-entrypoint.sh"]
-          imagePullPolicy: Always
-
-          envFrom:
-            - configMapRef:
-                name: {{ .Release.Name }}-kerberos-env
-
-          volumeMounts:
-            - name: entrypoints
-              mountPath: /etc/entrypoints.d
-            - name: shared
-              mountPath: /shared
-            # Kerberos related
-            - name: kerberos-conf-files
-              mountPath: /etc/krb5.conf
-              subPath: krb5.conf
-            - name: kerberos-keytab
-              mountPath: /etc/krb5.keytab
-              subPath: krb5.keytab
-              readOnly: true
 
       hostAliases:
       # Logon 04

--- a/charts/rabbit-consumer/templates/deployment.yaml
+++ b/charts/rabbit-consumer/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-kerberos-env
+          lifecycle:
+            postStart:
+              exec:
+                command: ["/bin/sh", "-c", "while [ ! -f /shared/krb5cc ]; do sleep 1; done"]
 
           startupProbe:
             exec:


### PR DESCRIPTION
Waits for the Kerberos sidecar to get going before we actually start the consumers.

This adds:
- Re-orders the startup, so Kerberos always goes first for obvious reasons
- A liveness and startup probe to check that the current kerberos creds are valid and restart the container if they ever are not
- A post lifecycle hook to delay the consumer until we see the shared creds


The result, we no longer error 2-4 times on prod (which can be a bit slower to get going):
![image](https://github.com/stfc/SCD-OpenStack-Utils/assets/1817032/bceb8733-03db-4593-b3f4-b45bc46b03e1)
