### PR TITLE
Ensure output directory exists

### DIFF
--- a/aq_zombie_finder/aq_zombie_finder.py
+++ b/aq_zombie_finder/aq_zombie_finder.py
@@ -153,9 +153,7 @@ def aq_zombie_finder():
     openstack_zombie_filepath = os.path.join(
         output_location, "openstack_zombie_list.txt"
     )
-    aquilon_zombie_filepath = os.path.join(
-        output_location, "aquilon_zombie_list.txt"
-    )
+    aquilon_zombie_filepath = os.path.join(output_location, "aquilon_zombie_list.txt")
 
     # Check if output files already exist
     for filepath in [

--- a/aq_zombie_finder/aq_zombie_finder.py
+++ b/aq_zombie_finder/aq_zombie_finder.py
@@ -1,4 +1,5 @@
 from re import compile as re_compile
+from pathlib import Path
 import argparse
 import os
 import sys
@@ -139,18 +140,21 @@ def aq_zombie_finder():
     user = args.user
     password = args.password
     openstack_ip = args.ip
-    output = args.output
+    output_location = args.output or "output"
 
     # Create a paramiko SSH client to the VM running Openstack and to Aquilon
     openstack_client = create_client(openstack_ip, user, password)
     aquilon_client = create_client("aquilon.gridpp.rl.ac.uk", user, password)
 
+    # Ensure output directory exists
+    Path(output_location).mkdir(exist_ok=True)
+
     # Define the filepath for the output to be saved to
     openstack_zombie_filepath = os.path.join(
-        output or "output", "openstack_zombie_list.txt"
+        output_location, "openstack_zombie_list.txt"
     )
     aquilon_zombie_filepath = os.path.join(
-        output or "output", "aquilon_zombie_list.txt"
+        output_location, "aquilon_zombie_list.txt"
     )
 
     # Check if output files already exist

--- a/aq_zombie_finder/aq_zombie_finder.py
+++ b/aq_zombie_finder/aq_zombie_finder.py
@@ -136,6 +136,13 @@ def parse_args(inp_args):
 
 
 def aq_zombie_finder():
+    """
+    Main Function to query aquilon to get a list of IPs of
+    VMs with Aquilon images, check if VMs that no longer
+    exist are still being managed by Aquilon or if VMs that
+    should be managed by Aquilon aren't, then output the IPs
+    into 2 files.
+    """
     # Define the variables with the script arguments
     args = parse_args(sys.argv[1:])
     user = args.user

--- a/aq_zombie_finder/aq_zombie_finder.py
+++ b/aq_zombie_finder/aq_zombie_finder.py
@@ -129,6 +129,7 @@ def parse_args(inp_args):
         "--output",
         metavar="OUTPUT",
         help="Directory to create the output files in",
+        default="output",
     )
     args = parser.parse_args(inp_args)
     return args
@@ -140,7 +141,7 @@ def aq_zombie_finder():
     user = args.user
     password = args.password
     openstack_ip = args.ip
-    output_location = args.output or "output"
+    output_location = args.output
 
     # Create a paramiko SSH client to the VM running Openstack and to Aquilon
     openstack_client = create_client(openstack_ip, user, password)

--- a/dns_entry_checker/dns_entry_checker.py
+++ b/dns_entry_checker/dns_entry_checker.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from re import compile as re_compile
+from pathlib import Path
 import argparse
 import os
 import sys
@@ -148,7 +149,7 @@ def dns_entry_checker():
     user = args.user
     password = args.password
     ip = args.ip
-    output = args.output
+    output_location = args.output or "output"
 
     # Create an SSH client with the credentials given
     client = create_client(ip, user, password)
@@ -162,17 +163,20 @@ def dns_entry_checker():
         "grep '172.16.'",
     )
 
+    # Ensure output directory exists
+    Path(output_location).mkdir(exist_ok=True)
+
     # Define the filepath for the output to be saved to
     forward_mismatch_filepath = os.path.join(
-        output or "output", "forward_mismatch_list.txt"
+        output_location, "forward_mismatch_list.txt"
     )
     backward_mismatch_filepath = os.path.join(
-        output or "output", "backward_mismatch_list.txt"
+        output_location, "backward_mismatch_list.txt"
     )
     backward_missing_filepath = os.path.join(
-        output or "output", "backward_missing_list.txt"
+        output_location, "backward_missing_list.txt"
     )
-    gap_missing_filepath = os.path.join(output or "output", "gap_missing_list.txt")
+    gap_missing_filepath = os.path.join(output_location, "gap_missing_list.txt")
 
     # Check if output files already exist
     for filepath in [

--- a/dns_entry_checker/dns_entry_checker.py
+++ b/dns_entry_checker/dns_entry_checker.py
@@ -138,6 +138,7 @@ def parse_args(inp_args):
         "--output",
         metavar="OUTPUT",
         help="Directory to create the output files in",
+        default="output",
     )
     args = parser.parse_args(inp_args)
     return args
@@ -149,7 +150,7 @@ def dns_entry_checker():
     user = args.user
     password = args.password
     ip = args.ip
-    output_location = args.output or "output"
+    output_location = args.output
 
     # Create an SSH client with the credentials given
     client = create_client(ip, user, password)

--- a/dns_entry_checker/dns_entry_checker.py
+++ b/dns_entry_checker/dns_entry_checker.py
@@ -145,6 +145,12 @@ def parse_args(inp_args):
 
 
 def dns_entry_checker():
+    """
+    Main Function to get a list of IP's and matching DNS'
+    and check whether there are mismatches, missing values
+    or gaps in the list, then output those IPs and DNS' into
+    4 files.
+    """
     # Define the variables with the script arguments
     args = parse_args(sys.argv[1:])
     user = args.user

--- a/dns_entry_checker/test/test_dns_entry_checker.py
+++ b/dns_entry_checker/test/test_dns_entry_checker.py
@@ -206,7 +206,7 @@ class DNSEntryCheckerTests(unittest.TestCase):
         self.assertEqual(
             args,
             Namespace(
-                user="test_user", password="test_pass", ip="test_ip", output=None
+                user="test_user", password="test_pass", ip="test_ip", output="output"
             ),
         )
 


### PR DESCRIPTION
GitHub doesn't include empty folders, so as such a check is required to ensure that the output folder exists, either by default or where specified.