### PR TITLE
Prototype Vault rabbit consumers

### DIFF
--- a/OpenStack-Rabbit-Consumer/rabbit_consumer/consumer_config.py
+++ b/OpenStack-Rabbit-Consumer/rabbit_consumer/consumer_config.py
@@ -48,6 +48,19 @@ class _VaultFields:
 
 
 @dataclass
+class _EtcdFields:
+    """
+    Dataclass for all Vault config elements. These are pulled from
+    environment variables.
+    """
+
+    etcd_host: str = field(default_factory=partial(os.getenv, "ETCD_HOST"))
+    etcd_port: str = field(default_factory=partial(os.getenv, "ETCD_PORT"))
+    etcd_username: str = field(default_factory=partial(os.getenv, "ETCD_USERNAME"))
+    etcd_password: str = field(default_factory=partial(os.getenv, "ETCD_PASSWORD"))
+
+
+@dataclass
 class _RabbitFields:
     """
     Dataclass for all RabbitMQ config elements. These are pulled from
@@ -65,7 +78,7 @@ class _RabbitFields:
 
 
 @dataclass
-class ConsumerConfig(_AqFields, _OpenstackFields, _VaultFields, _RabbitFields):
+class ConsumerConfig(_AqFields, _OpenstackFields, _VaultFields, _EtcdFields, _RabbitFields):
     """
     Mix-in class for all known config elements
     """

--- a/OpenStack-Rabbit-Consumer/rabbit_consumer/consumer_config.py
+++ b/OpenStack-Rabbit-Consumer/rabbit_consumer/consumer_config.py
@@ -36,6 +36,18 @@ class _OpenstackFields:
 
 
 @dataclass
+class _VaultFields:
+    """
+    Dataclass for all Vault config elements. These are pulled from
+    environment variables.
+    """
+
+    vault_role_id: str = field(default_factory=partial(os.getenv, "VAULT_ROLE_ID"))
+    vault_secret_id: str = field(default_factory=partial(os.getenv, "VAULT_SECRET_ID"))
+    vault_url: str = field(default_factory=partial(os.getenv, "VAULT_URL"))
+
+
+@dataclass
 class _RabbitFields:
     """
     Dataclass for all RabbitMQ config elements. These are pulled from
@@ -53,7 +65,7 @@ class _RabbitFields:
 
 
 @dataclass
-class ConsumerConfig(_AqFields, _OpenstackFields, _RabbitFields):
+class ConsumerConfig(_AqFields, _OpenstackFields, _VaultFields, _RabbitFields):
     """
     Mix-in class for all known config elements
     """

--- a/OpenStack-Rabbit-Consumer/rabbit_consumer/etcd_api.py
+++ b/OpenStack-Rabbit-Consumer/rabbit_consumer/etcd_api.py
@@ -1,0 +1,42 @@
+import logging
+import etcd3
+
+from rabbit_consumer.consumer_config import ConsumerConfig
+
+logger = logging.getLogger(__name__)
+
+class EtcdClient:
+    """
+    Wrapper for etcd client.
+    """
+
+    def __init__(self):
+        self.client = None
+
+    def __enter__(self):
+        self.client = etcd3.client(
+            host=ConsumerConfig().etcd_host,
+            port=int(ConsumerConfig().etcd_port),
+            user=ConsumerConfig().etcd_username,
+            password=ConsumerConfig().etcd_password,
+        )
+        return self.client
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.client.close()
+
+
+def etcd_put(key: str, value: str):
+    """
+    Put value into etcd
+    """
+    with EtcdClient() as client:
+        client.put(key, value)
+
+
+def etcd_get(key: str):
+    """
+    Get value from etcd
+    """
+    with EtcdClient() as client:
+        return client.get(key)

--- a/OpenStack-Rabbit-Consumer/rabbit_consumer/vault_api.py
+++ b/OpenStack-Rabbit-Consumer/rabbit_consumer/vault_api.py
@@ -1,0 +1,143 @@
+import logging
+from typing import List
+
+import hvac
+
+from rabbit_consumer.consumer_config import ConsumerConfig
+
+logger = logging.getLogger(__name__)
+
+
+class VaultClient:
+    """
+    Wrapper for Vault client.
+    """
+
+    def __init__(self):
+        self.client = None
+
+    def __enter__(self):
+        self.client = hvac.Client(url=ConsumerConfig().vault_url, verify=False)
+        self.client.auth.approle.login(
+            role_id=ConsumerConfig().vault_role_id,
+            secret_id=ConsumerConfig().vault_secret_id,
+            mount_point="admin",
+        )
+        return self.client
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.client.logout()
+
+
+def is_authenticated():
+    """
+    Checks for successful authenticaion with Vault
+    """
+    with VaultClient() as client:
+        assert client.is_authenticated()
+
+
+def check_vault_group_exists(vault_group: str) -> bool:
+    """
+    Checks given group mount point exists in vault
+    """
+    with VaultClient() as client:
+        try:
+            client.sys.read_auth_method_tuning(path=vault_group)
+            return True
+        except:
+            logger.warning("Vault group %s not found", vault_group)
+            return False
+
+
+def check_approle_exists(approle: str, vault_group: str) -> bool:
+    """
+    Checks if AppRole exists in Vault group
+    """
+    logger.info("Checking AppRole %s exists", approle)
+    with VaultClient() as client:
+        try:
+            client.auth.approle.read_role(role_name=approle, mount_point=vault_group)
+            return True
+        except:
+            logger.warning(
+                "Vault approle %s not found in group %s", approle, vault_group
+            )
+            return False
+
+
+def get_wrapped_secret_id(approle, vault_group, vm_uuid) -> str:
+    """
+    Requests wrapped secret id from Vault for an Approle
+    """
+    with VaultClient() as client:
+        return client.auth.approle.generate_secret_id(
+            role_name=approle,
+            mount_point=vault_group,
+            wrap_ttl="600s",
+            metadata={"openstack_uuid": vm_uuid},
+        )
+
+
+def get_secret_id_token(wrapped_secret_id) -> str:
+    """
+    Returns token for wrapped secret id
+    """
+    return wrapped_secret_id["wrap_info"]["token"]
+
+
+def list_approle_secret_accessors(approle, vault_group) -> List[str]:
+    """
+    List secret accessor for a given AppRole
+    """
+    try:
+        with VaultClient() as client:
+            return client.auth.approle.list_secret_id_accessors(
+                role_name=approle,
+                mount_point=vault_group,
+            )["data"]["keys"]
+    except:
+        return []
+
+
+def get_secret_accessor_metadata(approle, vault_group, secret_accessor) -> dict:
+    """
+    Get metadata for a given AppRole
+    """
+    with VaultClient() as client:
+        return client.auth.approle.read_secret_id_accessor(
+            role_name=approle,
+            secret_id_accessor=secret_accessor,
+            mount_point=vault_group,
+        )["data"]["metadata"]
+
+
+def get_vm_secret_accessors(approle, vault_group, vm_uuid) -> List[str]:
+    """
+    Get secret accessors for the AppRole assocciated with a VM
+    """
+    secret_accessors = list_approle_secret_accessors(
+        approle=approle, vault_group=vault_group
+    )
+    vm_secret_accessors = []
+    for i in secret_accessors:
+        if (
+            get_secret_accessor_metadata(
+                approle=approle, vault_group=vault_group, secret_accessor=i
+            ).get("openstack_uuid")
+            == vm_uuid
+        ):
+            vm_secret_accessors.append(i)
+    return vm_secret_accessors
+
+
+def revoke_secret_accessors(approle, vault_group, secret_accessors) -> None:
+    """
+    Revoke a list of secret accessors for a given AppRole
+    """
+    with VaultClient() as client:
+        for i in secret_accessors:
+            client.auth.approle.destroy_secret_id_accessor(
+                role_name=approle, secret_id_accessor=i, mount_point=vault_group
+            )
+            logger.info("Revoked: " + i)

--- a/OpenStack-Rabbit-Consumer/rabbit_consumer/vault_metadata.py
+++ b/OpenStack-Rabbit-Consumer/rabbit_consumer/vault_metadata.py
@@ -1,0 +1,38 @@
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from mashumaro import DataClassDictMixin
+from mashumaro.config import BaseConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class VaultMetadata(DataClassDictMixin):
+    """
+    Deserialised metadata that is set a VM's metadata
+    """
+
+    vault_group: str
+    vault_role: str
+
+    # pylint: disable=too-few-public-methods
+    class Config(BaseConfig):
+        """
+        Sets the aliases for the metadata keys
+        """
+
+        aliases = {
+            "vault_group": "VAULT_GROUP",
+            "vault_role": "VAULT_ROLE",
+        }
+
+    def override_from_vm_meta(self, vm_meta: Dict[str, str]):
+        """
+        Overrides the values in the metadata with the values from the VM's
+        metadata
+        """
+        for attr, alias in self.Config.aliases.items():
+            if alias in vm_meta:
+                setattr(self, attr, vm_meta[alias])


### PR DESCRIPTION
This is a prototype for vault integrated machine provisioning with openstack.

When a create message is received a wrapped secret id is requested and stored in etcd. On a delete message all secret ids associated with the approle and VM uuid are revoked.