### PR TITLE
BUG: Read csv operation on closed file error.

### DIFF
--- a/pynetbox_data_uploader/lib/utils/csv_to_dataclass.py
+++ b/pynetbox_data_uploader/lib/utils/csv_to_dataclass.py
@@ -11,7 +11,7 @@ def open_file(file_path: str) -> List[Dict]:
     """
     with open(file_path, encoding="UTF-8") as file:
         csv_reader_obj = csv.DictReader(file)
-    return list(csv_reader_obj)
+        return list(csv_reader_obj)
 
 
 def separate_data(csv_dicts: List[Dict]) -> List[Device]:


### PR DESCRIPTION
A change in the previous PR de-indented the return in the with open(). This caused an error becaused in the return statement the list funcition is used on the reader object but no operations can be done on the reader object outside of the context manager.

The pylint will still fail on import errors. I am fixing this. Just noticed this bug which renders the code useless. :)