### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/OpenStack-AD-Migrate/usr/local/bin/openstack-ad-migrate.py
+++ b/OpenStack-AD-Migrate/usr/local/bin/openstack-ad-migrate.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 #!/usr/bin/python
 import ldap
 import ldap.sasl

--- a/OpenStack-Rabbit-Consumer/entrypoint.py
+++ b/OpenStack-Rabbit-Consumer/entrypoint.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 
 import logging
 import logging.handlers

--- a/OpenStack-Rabbit-Consumer/rabbit_consumer/aq_api.py
+++ b/OpenStack-Rabbit-Consumer/rabbit_consumer/aq_api.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 This file defines methods to be used to interact with the 
 Aquilon API

--- a/OpenStack-Rabbit-Consumer/rabbit_consumer/aq_metadata.py
+++ b/OpenStack-Rabbit-Consumer/rabbit_consumer/aq_metadata.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 This file defines the class to handle deserialised metadata for 
 Aquilon

--- a/OpenStack-Rabbit-Consumer/rabbit_consumer/consumer_config.py
+++ b/OpenStack-Rabbit-Consumer/rabbit_consumer/consumer_config.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 This file allows us to set environment variables so that
 credentials are not exposed

--- a/OpenStack-Rabbit-Consumer/rabbit_consumer/message_consumer.py
+++ b/OpenStack-Rabbit-Consumer/rabbit_consumer/message_consumer.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 This file manages how rabbit messages stating AQ VM creation and deletion 
 should be handled and processed between the consumer and Aquilon

--- a/OpenStack-Rabbit-Consumer/rabbit_consumer/openstack_address.py
+++ b/OpenStack-Rabbit-Consumer/rabbit_consumer/openstack_address.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 This file deserializes a server's network address from an
 OpenStack API response

--- a/OpenStack-Rabbit-Consumer/rabbit_consumer/openstack_api.py
+++ b/OpenStack-Rabbit-Consumer/rabbit_consumer/openstack_api.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 This file defines methods for connecting and interacting with the 
 OpenStack API

--- a/OpenStack-Rabbit-Consumer/rabbit_consumer/rabbit_message.py
+++ b/OpenStack-Rabbit-Consumer/rabbit_consumer/rabbit_message.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 This file handles how messages from Rabbit are processed and the 
 message extracted

--- a/OpenStack-Rabbit-Consumer/rabbit_consumer/vm_data.py
+++ b/OpenStack-Rabbit-Consumer/rabbit_consumer/vm_data.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 This file has a dataclass for creating VM data objects from messages
 """

--- a/OpenStack-Rabbit-Consumer/test/fixtures.py
+++ b/OpenStack-Rabbit-Consumer/test/fixtures.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 Fixtures for unit tests, used to create mock objects
 """

--- a/OpenStack-Rabbit-Consumer/test/test_aq_api.py
+++ b/OpenStack-Rabbit-Consumer/test/test_aq_api.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 Tests that we perform the correct REST requests against
 the Aquilon API

--- a/OpenStack-Rabbit-Consumer/test/test_aq_metadata.py
+++ b/OpenStack-Rabbit-Consumer/test/test_aq_metadata.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 Tests the AQ metadata dataclass, including
 init from environment variables, and overriding values

--- a/OpenStack-Rabbit-Consumer/test/test_consumer_config.py
+++ b/OpenStack-Rabbit-Consumer/test/test_consumer_config.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 Test the consumer config class, this handles the environment variables
 that are used to configure the consumer.

--- a/OpenStack-Rabbit-Consumer/test/test_message_consumer.py
+++ b/OpenStack-Rabbit-Consumer/test/test_message_consumer.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 Tests the message consumption flow
 for the consumer

--- a/OpenStack-Rabbit-Consumer/test/test_openstack_address.py
+++ b/OpenStack-Rabbit-Consumer/test/test_openstack_address.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 Tests the dataclass representing OpenStack network addresses
 """

--- a/OpenStack-Rabbit-Consumer/test/test_openstack_api.py
+++ b/OpenStack-Rabbit-Consumer/test/test_openstack_api.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 Tests that the Openstack API functions are invoked
 as expected with the correct params

--- a/OpenStack-Rabbit-Consumer/test/test_rabbit_message.py
+++ b/OpenStack-Rabbit-Consumer/test/test_rabbit_message.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 Tests rabbit messages are consumed correctly from the queue
 """

--- a/OpenStack-Rally-Tester/usr/local/bin/rally-run-test.sh
+++ b/OpenStack-Rally-Tester/usr/local/bin/rally-run-test.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 
 # Exit on error
 set -e

--- a/OpenStack-Rally-Tester/usr/local/bin/rally_extract_results.py
+++ b/OpenStack-Rally-Tester/usr/local/bin/rally_extract_results.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 Parses results from the rally task report and sends them to influxdb
 """

--- a/OpenStack-accounting/sql/cinder_get_accounting_data.sql
+++ b/OpenStack-accounting/sql/cinder_get_accounting_data.sql
@@ -1,3 +1,8 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2023 United Kingdom Research and Innovation
+*/
+
 CREATE PROCEDURE `get_accounting_data`(IN starttime datetime, IN endtime datetime)
 BEGIN
 /*

--- a/OpenStack-accounting/sql/glance_get_accounting_data.sql
+++ b/OpenStack-accounting/sql/glance_get_accounting_data.sql
@@ -1,3 +1,8 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2023 United Kingdom Research and Innovation
+*/
+
 CREATE PROCEDURE `get_accounting_data`(IN starttime datetime, IN endtime datetime)
 BEGIN
 /*

--- a/OpenStack-accounting/sql/manila_get_accounting_data.sql
+++ b/OpenStack-accounting/sql/manila_get_accounting_data.sql
@@ -1,3 +1,8 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2023 United Kingdom Research and Innovation
+*/
+
 CREATE PROCEDURE `get_accounting_data`(IN starttime datetime, IN endtime datetime)
 BEGIN
 /*

--- a/OpenStack-accounting/sql/nova_get_accounting_data.sql
+++ b/OpenStack-accounting/sql/nova_get_accounting_data.sql
@@ -1,3 +1,8 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2023 United Kingdom Research and Innovation
+*/
+
 CREATE PROCEDURE `get_accounting_data`(IN starttime datetime, IN endtime datetime)
 BEGIN
 /*

--- a/OpenStack-accounting/usr/local/sbin/accountinglib.py
+++ b/OpenStack-accounting/usr/local/sbin/accountinglib.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 import time
 import datetime
 #from datetime import datetime,time

--- a/OpenStack-accounting/usr/local/sbin/cinder_extract_accounting.py
+++ b/OpenStack-accounting/usr/local/sbin/cinder_extract_accounting.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 import accountinglib
 
 import sys

--- a/OpenStack-accounting/usr/local/sbin/glance_extract_accounting.py
+++ b/OpenStack-accounting/usr/local/sbin/glance_extract_accounting.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 import accountinglib
 
 import sys

--- a/OpenStack-accounting/usr/local/sbin/manila_extract_accounting.py
+++ b/OpenStack-accounting/usr/local/sbin/manila_extract_accounting.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 import accountinglib
 
 import sys

--- a/OpenStack-accounting/usr/local/sbin/nova_extract_accounting.py
+++ b/OpenStack-accounting/usr/local/sbin/nova_extract_accounting.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 import accountinglib
 
 import sys

--- a/OpenStack-accounting/usr/local/sbin/now-accounting.sh
+++ b/OpenStack-accounting/usr/local/sbin/now-accounting.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 
 # helper script for calculating accounting for today
 

--- a/OpenStack-accounting/usr/local/sbin/past-accounting.sh
+++ b/OpenStack-accounting/usr/local/sbin/past-accounting.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 
 # helper script for regenerating daily accounting over a period of time
 

--- a/OpenStack_get_username/var/www/cgi-bin/get_username.sh
+++ b/OpenStack_get_username/var/www/cgi-bin/get_username.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 
 echo "Content-Type: text/plain"
 echo ""

--- a/OpenStack_irisiam_mapper/var/www/cgi-bin/irisiam-mapper.py
+++ b/OpenStack_irisiam_mapper/var/www/cgi-bin/irisiam-mapper.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 import sys
 import os
 import json

--- a/aq_zombie_finder/aq_zombie_finder.py
+++ b/aq_zombie_finder/aq_zombie_finder.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from re import compile as re_compile
 from pathlib import Path
 import argparse

--- a/aq_zombie_finder/test/test_aq_zombie_finder.py
+++ b/aq_zombie_finder/test/test_aq_zombie_finder.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from unittest import mock
 from unittest.mock import MagicMock, patch, NonCallableMock, call
 from parameterized import parameterized

--- a/charts/rabbit-consumer/include/kinit.sh
+++ b/charts/rabbit-consumer/include/kinit.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 
 # Adapted from https://cloud.redhat.com/blog/kerberos-sidecar-container
 

--- a/charts/rabbit-consumer/include/sidecar-entrypoint.sh
+++ b/charts/rabbit-consumer/include/sidecar-entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 
 set -ex
 

--- a/dns_entry_checker/dns_entry_checker.py
+++ b/dns_entry_checker/dns_entry_checker.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from collections import defaultdict
 from re import compile as re_compile
 from pathlib import Path

--- a/dns_entry_checker/test/test_dns_entry_checker.py
+++ b/dns_entry_checker/test/test_dns_entry_checker.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from argparse import Namespace
 from collections import defaultdict
 from unittest import mock

--- a/gpu_benchmark/benchmark.sh
+++ b/gpu_benchmark/benchmark.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 
 set -e
 

--- a/gpu_benchmark/gpu_setup.sh
+++ b/gpu_benchmark/gpu_setup.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 
 sudo dnf update -y
 

--- a/gpu_benchmark/power_perf.sh
+++ b/gpu_benchmark/power_perf.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 
 set -e
 

--- a/iriscasttools/iriscasttools/__init__.py
+++ b/iriscasttools/iriscasttools/__init__.py
@@ -1,1 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from iriscasttools import __main__

--- a/iriscasttools/iriscasttools/__main__.py
+++ b/iriscasttools/iriscasttools/__main__.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 import logging
 import logging.handlers
 import os

--- a/iriscasttools/iriscasttools/stats.py
+++ b/iriscasttools/iriscasttools/stats.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 Collects energy usage metrics using IPMI, as well as other metrics such as CPU and RAM usage.
 """

--- a/iriscasttools/iriscasttools/utils.py
+++ b/iriscasttools/iriscasttools/utils.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 Provides utility functions to collect energy usage information
 """

--- a/iriscasttools/setup.py
+++ b/iriscasttools/setup.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from setuptools import setup, find_packages
 
 VERSION = "0.2.1"

--- a/iriscasttools/test/test_stats.py
+++ b/iriscasttools/test/test_stats.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 Tests for main functions for iriscasttools package
 """

--- a/iriscasttools/test/test_utils.py
+++ b/iriscasttools/test/test_utils.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 """
 Tests for utility functions for iriscasttools package
 """

--- a/jsm_metric_collection/jsm_metric_collection.py
+++ b/jsm_metric_collection/jsm_metric_collection.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from datetime import datetime
 from pathlib import Path

--- a/jsm_metric_collection/test/test_jsm_metric_collection.py
+++ b/jsm_metric_collection/test/test_jsm_metric_collection.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from unittest import mock
 from unittest.mock import MagicMock, patch, call
 from parameterized import parameterized

--- a/prometheus_ip_script/main.py
+++ b/prometheus_ip_script/main.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from ipaddress import IPv4Network
 from pathlib import Path
 from typing import List

--- a/prometheus_ip_script/test/test_generate_ips.py
+++ b/prometheus_ip_script/test/test_generate_ips.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from pathlib import Path
 
 from main import (

--- a/pynetbox_query/pynetboxquery/__main__.py
+++ b/pynetbox_query/pynetboxquery/__main__.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from importlib import import_module
 import sys
 from pynetboxquery.utils.error_classes import UserMethodNotFoundError

--- a/pynetbox_query/pynetboxquery/netbox_api/netbox_connect.py
+++ b/pynetbox_query/pynetboxquery/netbox_api/netbox_connect.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from pynetbox import api
 
 

--- a/pynetbox_query/pynetboxquery/netbox_api/netbox_create.py
+++ b/pynetbox_query/pynetboxquery/netbox_api/netbox_create.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from typing import Union, Dict, List
 
 

--- a/pynetbox_query/pynetboxquery/netbox_api/netbox_get_id.py
+++ b/pynetbox_query/pynetboxquery/netbox_api/netbox_get_id.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from pynetboxquery.utils.device_dataclass import Device
 
 

--- a/pynetbox_query/pynetboxquery/netbox_api/validate_data.py
+++ b/pynetbox_query/pynetboxquery/netbox_api/validate_data.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from typing import List
 from pynetbox import api
 from pynetboxquery.utils.device_dataclass import Device

--- a/pynetbox_query/pynetboxquery/user_methods/abstract_user_method.py
+++ b/pynetbox_query/pynetboxquery/user_methods/abstract_user_method.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from abc import ABC, abstractmethod
 from typing import List, Dict
 from argparse import ArgumentParser

--- a/pynetbox_query/pynetboxquery/user_methods/upload_devices_to_netbox.py
+++ b/pynetbox_query/pynetboxquery/user_methods/upload_devices_to_netbox.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from dataclasses import asdict
 from pynetboxquery.utils.read_utils.read_file import ReadFile
 from pynetboxquery.netbox_api.validate_data import ValidateData

--- a/pynetbox_query/pynetboxquery/user_methods/validate_data_fields_in_netbox.py
+++ b/pynetbox_query/pynetboxquery/user_methods/validate_data_fields_in_netbox.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from pynetboxquery.utils.parsers import Parsers
 from pynetboxquery.netbox_api.validate_data import ValidateData
 from pynetboxquery.utils.read_utils.read_file import ReadFile

--- a/pynetbox_query/pynetboxquery/utils/device_dataclass.py
+++ b/pynetbox_query/pynetboxquery/utils/device_dataclass.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from dataclasses import dataclass, fields
 from typing import Optional
 

--- a/pynetbox_query/pynetboxquery/utils/error_classes.py
+++ b/pynetbox_query/pynetboxquery/utils/error_classes.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 # Disabling this Pylint error as these classes do not need Docstring.
 # They are just errors
 # pylint: disable = C0115

--- a/pynetbox_query/pynetboxquery/utils/parsers.py
+++ b/pynetbox_query/pynetboxquery/utils/parsers.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 import argparse
 
 

--- a/pynetbox_query/pynetboxquery/utils/query_device.py
+++ b/pynetbox_query/pynetboxquery/utils/query_device.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from typing import List
 from pynetboxquery.utils.device_dataclass import Device
 from pynetboxquery.netbox_api.netbox_get_id import NetboxGetId

--- a/pynetbox_query/pynetboxquery/utils/read_utils/read_abc.py
+++ b/pynetbox_query/pynetboxquery/utils/read_utils/read_abc.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import List, Dict

--- a/pynetbox_query/pynetboxquery/utils/read_utils/read_csv.py
+++ b/pynetbox_query/pynetboxquery/utils/read_utils/read_csv.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from csv import DictReader
 from typing import List
 from pynetboxquery.utils.device_dataclass import Device

--- a/pynetbox_query/pynetboxquery/utils/read_utils/read_file.py
+++ b/pynetbox_query/pynetboxquery/utils/read_utils/read_file.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from typing import List
 from pynetboxquery.utils.device_dataclass import Device
 from pynetboxquery.utils.error_classes import FileTypeNotSupportedError

--- a/pynetbox_query/pynetboxquery/utils/read_utils/read_txt.py
+++ b/pynetbox_query/pynetboxquery/utils/read_utils/read_txt.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from csv import DictReader
 from typing import List
 from pynetboxquery.utils.device_dataclass import Device

--- a/pynetbox_query/pynetboxquery/utils/read_utils/read_xlsx.py
+++ b/pynetbox_query/pynetboxquery/utils/read_utils/read_xlsx.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from typing import List
 from pandas import read_excel
 from pynetboxquery.utils.device_dataclass import Device

--- a/pynetbox_query/setup.py
+++ b/pynetbox_query/setup.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from setuptools import setup, find_packages
 
 VERSION = "0.1.0"

--- a/pynetbox_query/tests/conftest.py
+++ b/pynetbox_query/tests/conftest.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from typing import Dict
 from pytest import fixture
 from pynetboxquery.utils.device_dataclass import Device

--- a/pynetbox_query/tests/test__main__.py
+++ b/pynetbox_query/tests/test__main__.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from unittest.mock import patch
 from pytest import raises
 from pynetboxquery.__main__ import main

--- a/pynetbox_query/tests/test_netbox_api/test_netbox_connect.py
+++ b/pynetbox_query/tests/test_netbox_api/test_netbox_connect.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from unittest.mock import patch
 from pynetboxquery.netbox_api.netbox_connect import api_object
 

--- a/pynetbox_query/tests/test_netbox_api/test_netbox_create.py
+++ b/pynetbox_query/tests/test_netbox_api/test_netbox_create.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from unittest.mock import NonCallableMock
 from dataclasses import asdict
 from pytest import fixture

--- a/pynetbox_query/tests/test_netbox_api/test_netbox_get_id.py
+++ b/pynetbox_query/tests/test_netbox_api/test_netbox_get_id.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from unittest.mock import patch
 from pytest import fixture
 from pynetboxquery.netbox_api.netbox_get_id import NetboxGetId

--- a/pynetbox_query/tests/test_netbox_api/test_validate_data.py
+++ b/pynetbox_query/tests/test_netbox_api/test_validate_data.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from unittest.mock import patch, NonCallableMock
 from pytest import fixture
 from pynetboxquery.netbox_api.validate_data import ValidateData

--- a/pynetbox_query/tests/test_user_methods/test_abstract_user_method.py
+++ b/pynetbox_query/tests/test_user_methods/test_abstract_user_method.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from argparse import ArgumentParser
 from typing import List
 from unittest.mock import patch

--- a/pynetbox_query/tests/test_user_methods/test_upload_devices_to_netbox.py
+++ b/pynetbox_query/tests/test_user_methods/test_upload_devices_to_netbox.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from dataclasses import asdict
 from unittest.mock import patch, NonCallableMock
 from pynetboxquery.user_methods.upload_devices_to_netbox import Main

--- a/pynetbox_query/tests/test_user_methods/test_validate_data_fields_in_netbox.py
+++ b/pynetbox_query/tests/test_user_methods/test_validate_data_fields_in_netbox.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from unittest.mock import patch, NonCallableMock
 from pynetboxquery.user_methods.validate_data_fields_in_netbox import Main
 

--- a/pynetbox_query/tests/test_utils/test_device_dataclass.py
+++ b/pynetbox_query/tests/test_utils/test_device_dataclass.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from dataclasses import asdict
 
 

--- a/pynetbox_query/tests/test_utils/test_parsers.py
+++ b/pynetbox_query/tests/test_utils/test_parsers.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from unittest.mock import patch
 from pytest import fixture
 from pynetboxquery.utils.parsers import Parsers

--- a/pynetbox_query/tests/test_utils/test_query_device.py
+++ b/pynetbox_query/tests/test_utils/test_query_device.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from unittest.mock import NonCallableMock, patch
 from dataclasses import asdict
 from pytest import fixture

--- a/pynetbox_query/tests/test_utils/test_read_utils/test_read_abc.py
+++ b/pynetbox_query/tests/test_utils/test_read_utils/test_read_abc.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from dataclasses import asdict
 from unittest.mock import patch
 from pytest import raises

--- a/pynetbox_query/tests/test_utils/test_read_utils/test_read_csv.py
+++ b/pynetbox_query/tests/test_utils/test_read_utils/test_read_csv.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from unittest.mock import patch
 from pynetboxquery.utils.read_utils.read_csv import ReadCSV
 

--- a/pynetbox_query/tests/test_utils/test_read_utils/test_read_file.py
+++ b/pynetbox_query/tests/test_utils/test_read_utils/test_read_file.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from unittest.mock import patch
 from pytest import raises
 from pynetboxquery.utils.read_utils.read_file import ReadFile

--- a/pynetbox_query/tests/test_utils/test_read_utils/test_read_txt.py
+++ b/pynetbox_query/tests/test_utils/test_read_utils/test_read_txt.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from unittest.mock import patch
 from pytest import raises
 from pynetboxquery.utils.read_utils.read_txt import ReadTXT

--- a/pynetbox_query/tests/test_utils/test_read_utils/test_read_xlsx.py
+++ b/pynetbox_query/tests/test_utils/test_read_utils/test_read_xlsx.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2023 United Kingdom Research and Innovation
 from unittest.mock import patch
 from pytest import raises
 from pynetboxquery.utils.read_utils.read_xlsx import ReadXLSX


### PR DESCRIPTION
Adds the Apache 2.0 license to allow code re-use. We've chosen this license for this repo because:

- We don't mind people adapting and either partial or complete bits of code for their own projects.

- Any modifications is likely to be bespoke to their env. and needs. Whilst it would be nice to share around, a strong copy-left requirement is likely to prevent people re-using bits, which we wouldn't likely benefit from anyway.

- It still allows attribution, as we're just as happy to collaborate where we can too.

---

Resolves: #123 