### PR TITLE
ENH: add grafana monitoring scripts

### DIFF
--- a/MonitoringTools/tests/test_limits_to_influx.py
+++ b/MonitoringTools/tests/test_limits_to_influx.py
@@ -1,0 +1,108 @@
+from unittest.mock import patch, call, NonCallableMock
+from limits_to_influx import convert_to_data_string, get_limit_prop_string, get_all_limits, main
+import pytest
+
+
+def test_convert_to_data_string_no_items():
+    """
+    Tests convert_to_data_string returns empty string when given no empty dict as limit_details
+    """
+    assert convert_to_data_string(NonCallableMock(), {}) == ""
+
+
+@patch("limits_to_influx.get_limit_prop_string")
+def test_convert_to_data_string_one_item(mock_get_limit_prop_string):
+    """
+    Tests convert_to_data_string works with single entry in dict for limit_details
+    """
+    mock_instance = "prod"
+    mock_project_details = NonCallableMock()
+    mock_limit_details = {"project foo": mock_project_details}
+    mock_get_limit_prop_string.return_value = "prop1=val1"
+
+    res = convert_to_data_string(mock_instance, mock_limit_details)
+    assert res == 'Limits,Project="project\ foo",instance=Prod prop1=val1'
+    mock_get_limit_prop_string.assert_called_once_with(mock_project_details)
+
+
+@patch("limits_to_influx.get_limit_prop_string")
+def test_convert_to_data_string_multi_item(mock_get_limit_prop_string):
+    """
+    Tests convert_to_data_string works with multiple entries in dict for limit_details
+    """
+    mock_instance = "prod"
+    mock_project_details = NonCallableMock()
+
+    mock_limit_details = {
+        "project foo": mock_project_details,
+        "project bar": mock_project_details
+    }
+    mock_get_limit_prop_string.side_effect = ["prop1=val1", "prop1=val2"]
+    assert (
+        convert_to_data_string(mock_instance, mock_limit_details) ==
+        'Limits,Project="project\ foo",instance=Prod prop1=val1'
+        'Limits,Project="project\ bar",instance=Prod prop1=val2'
+    )
+
+
+@pytest.mark.parametrize("details, expected", [
+    ({}, ""),
+    ({"key1": "123"}, "key1=123i"),
+    ({"key1": "123", "key2": "456", "key3": "789"}, "key1=123i,key2=456i,key3=789i"),
+])
+def test_limit_prop_string(details, expected):
+    """
+    tests get_limit_prop_string converts dict into data string properly
+    """
+    assert get_limit_prop_string(details) == expected
+
+
+def test_get_limits_for_project():
+    # TODO: once we rewrite to using openstacksdk
+    pass
+
+
+@patch("limits_to_influx.openstack")
+@patch("limits_to_influx.get_limits_for_project")
+@patch("limits_to_influx.convert_to_data_string")
+def test_get_all_limits(mock_convert_to_data_string, mock_get_limits_for_project, mock_openstack):
+    """
+    tests get_all_limits function gets the limits of project appropriately
+    """
+    mock_project_list = [
+        # to be ignored
+        {"name": "xyz_rally", "id": "foo"},
+        {"name": "844_xyz", "id": "bar"},
+        # not to be ignored
+        {"name": "proj1", "id": "proj1-id"},
+        {"name": "proj2", "id": "proj2-id"}
+    ]
+    mock_conn_obj = mock_openstack.connect.return_value
+    mock_conn_obj.list_projects.return_value = mock_project_list
+
+    mock_instance = NonCallableMock()
+    res = get_all_limits(mock_instance)
+    mock_openstack.connect.assert_called_once_with(cloud=mock_instance)
+    mock_conn_obj.list_projects.assert_called_once()
+    mock_get_limits_for_project.assert_has_calls([
+        call(mock_instance, "proj1-id"),
+        call(mock_instance, "proj2-id")
+    ])
+
+    mock_convert_to_data_string.assert_called_once_with(
+        mock_instance,
+        {
+            "proj1": mock_get_limits_for_project.return_value,
+            "proj2": mock_get_limits_for_project.return_value
+        }
+    )
+    assert res == mock_convert_to_data_string.return_value
+
+
+@patch("limits_to_influx.run_scrape")
+@patch("limits_to_influx.parse_args")
+def test_main(mock_parse_args, mock_run_scrape):
+    mock_user_args = NonCallableMock()
+    main(mock_user_args)
+    mock_run_scrape.assert_called_once_with(mock_parse_args.return_value, get_all_limits)
+    mock_parse_args.assert_called_once_with(mock_user_args, description="Get All Project Limits")

--- a/MonitoringTools/tests/test_limits_to_influx.py
+++ b/MonitoringTools/tests/test_limits_to_influx.py
@@ -114,6 +114,9 @@ def test_get_all_limits(
 @patch("limits_to_influx.run_scrape")
 @patch("limits_to_influx.parse_args")
 def test_main(mock_parse_args, mock_run_scrape):
+    """
+    tests main function calls run_scrape utility function properly
+    """
     mock_user_args = NonCallableMock()
     main(mock_user_args)
     mock_run_scrape.assert_called_once_with(

--- a/MonitoringTools/tests/test_limits_to_influx.py
+++ b/MonitoringTools/tests/test_limits_to_influx.py
@@ -1,5 +1,10 @@
 from unittest.mock import patch, call, NonCallableMock
-from limits_to_influx import convert_to_data_string, get_limit_prop_string, get_all_limits, main
+from limits_to_influx import (
+    convert_to_data_string,
+    get_limit_prop_string,
+    get_all_limits,
+    main,
+)
 import pytest
 
 
@@ -35,21 +40,27 @@ def test_convert_to_data_string_multi_item(mock_get_limit_prop_string):
 
     mock_limit_details = {
         "project foo": mock_project_details,
-        "project bar": mock_project_details
+        "project bar": mock_project_details,
     }
     mock_get_limit_prop_string.side_effect = ["prop1=val1", "prop1=val2"]
     assert (
-        convert_to_data_string(mock_instance, mock_limit_details) ==
-        'Limits,Project="project\ foo",instance=Prod prop1=val1'
+        convert_to_data_string(mock_instance, mock_limit_details)
+        == 'Limits,Project="project\ foo",instance=Prod prop1=val1'
         'Limits,Project="project\ bar",instance=Prod prop1=val2'
     )
 
 
-@pytest.mark.parametrize("details, expected", [
-    ({}, ""),
-    ({"key1": "123"}, "key1=123i"),
-    ({"key1": "123", "key2": "456", "key3": "789"}, "key1=123i,key2=456i,key3=789i"),
-])
+@pytest.mark.parametrize(
+    "details, expected",
+    [
+        ({}, ""),
+        ({"key1": "123"}, "key1=123i"),
+        (
+            {"key1": "123", "key2": "456", "key3": "789"},
+            "key1=123i,key2=456i,key3=789i",
+        ),
+    ],
+)
 def test_limit_prop_string(details, expected):
     """
     tests get_limit_prop_string converts dict into data string properly
@@ -65,7 +76,9 @@ def test_get_limits_for_project():
 @patch("limits_to_influx.openstack")
 @patch("limits_to_influx.get_limits_for_project")
 @patch("limits_to_influx.convert_to_data_string")
-def test_get_all_limits(mock_convert_to_data_string, mock_get_limits_for_project, mock_openstack):
+def test_get_all_limits(
+    mock_convert_to_data_string, mock_get_limits_for_project, mock_openstack
+):
     """
     tests get_all_limits function gets the limits of project appropriately
     """
@@ -75,7 +88,7 @@ def test_get_all_limits(mock_convert_to_data_string, mock_get_limits_for_project
         {"name": "844_xyz", "id": "bar"},
         # not to be ignored
         {"name": "proj1", "id": "proj1-id"},
-        {"name": "proj2", "id": "proj2-id"}
+        {"name": "proj2", "id": "proj2-id"},
     ]
     mock_conn_obj = mock_openstack.connect.return_value
     mock_conn_obj.list_projects.return_value = mock_project_list
@@ -84,17 +97,16 @@ def test_get_all_limits(mock_convert_to_data_string, mock_get_limits_for_project
     res = get_all_limits(mock_instance)
     mock_openstack.connect.assert_called_once_with(cloud=mock_instance)
     mock_conn_obj.list_projects.assert_called_once()
-    mock_get_limits_for_project.assert_has_calls([
-        call(mock_instance, "proj1-id"),
-        call(mock_instance, "proj2-id")
-    ])
+    mock_get_limits_for_project.assert_has_calls(
+        [call(mock_instance, "proj1-id"), call(mock_instance, "proj2-id")]
+    )
 
     mock_convert_to_data_string.assert_called_once_with(
         mock_instance,
         {
             "proj1": mock_get_limits_for_project.return_value,
-            "proj2": mock_get_limits_for_project.return_value
-        }
+            "proj2": mock_get_limits_for_project.return_value,
+        },
     )
     assert res == mock_convert_to_data_string.return_value
 
@@ -104,5 +116,9 @@ def test_get_all_limits(mock_convert_to_data_string, mock_get_limits_for_project
 def test_main(mock_parse_args, mock_run_scrape):
     mock_user_args = NonCallableMock()
     main(mock_user_args)
-    mock_run_scrape.assert_called_once_with(mock_parse_args.return_value, get_all_limits)
-    mock_parse_args.assert_called_once_with(mock_user_args, description="Get All Project Limits")
+    mock_run_scrape.assert_called_once_with(
+        mock_parse_args.return_value, get_all_limits
+    )
+    mock_parse_args.assert_called_once_with(
+        mock_user_args, description="Get All Project Limits"
+    )

--- a/MonitoringTools/tests/test_limits_to_influx.py
+++ b/MonitoringTools/tests/test_limits_to_influx.py
@@ -10,7 +10,7 @@ import pytest
 
 def test_convert_to_data_string_no_items():
     """
-    Tests convert_to_data_string returns empty string when given no empty dict as limit_details
+    Tests convert_to_data_string returns empty string when given empty dict as limit_details
     """
     assert convert_to_data_string(NonCallableMock(), {}) == ""
 
@@ -26,7 +26,7 @@ def test_convert_to_data_string_one_item(mock_get_limit_prop_string):
     mock_get_limit_prop_string.return_value = "prop1=val1"
 
     res = convert_to_data_string(mock_instance, mock_limit_details)
-    assert res == 'Limits,Project="project\ foo",instance=Prod prop1=val1'
+    assert res == 'Limits,Project="project\ foo",instance=Prod prop1=val1\n'
     mock_get_limit_prop_string.assert_called_once_with(mock_project_details)
 
 
@@ -45,8 +45,8 @@ def test_convert_to_data_string_multi_item(mock_get_limit_prop_string):
     mock_get_limit_prop_string.side_effect = ["prop1=val1", "prop1=val2"]
     assert (
         convert_to_data_string(mock_instance, mock_limit_details)
-        == 'Limits,Project="project\ foo",instance=Prod prop1=val1'
-        'Limits,Project="project\ bar",instance=Prod prop1=val2'
+        == 'Limits,Project="project\ foo",instance=Prod prop1=val1\n'
+        'Limits,Project="project\ bar",instance=Prod prop1=val2\n'
     )
 
 

--- a/MonitoringTools/tests/test_send_metric_utils.py
+++ b/MonitoringTools/tests/test_send_metric_utils.py
@@ -17,22 +17,20 @@ def test_read_config_file_valid(mock_config_parser):
     mock_config_obj.items.side_effect = [
         [("password", "pass"), ("username", "user")],
         [("instance", "prod")],
-        [("database", "cloud"), ("host", "localhost:8086")]
+        [("database", "cloud"), ("host", "localhost:8086")],
     ]
     mock_filepath = NonCallableMock()
     res = read_config_file(mock_filepath)
     mock_config_parser.assert_called_once()
     mock_config_obj.sections.assert_called_once()
-    mock_config_obj.items.assert_has_calls([
-        call("auth"), call("cloud"), call("db")
-    ])
+    mock_config_obj.items.assert_has_calls([call("auth"), call("cloud"), call("db")])
 
     assert res == {
         "auth.password": "pass",
         "auth.username": "user",
         "cloud.instance": "prod",
         "db.database": "cloud",
-        "db.host": "localhost:8086"
+        "db.host": "localhost:8086",
     }
 
 
@@ -61,7 +59,7 @@ def test_post_to_influxdb_valid(mock_requests):
     mock_requests.post.assert_called_once_with(
         "http://localhost:8086/write?db=cloud&precision=s",
         data=mock_data_string,
-        auth=(mock_user, mock_pass)
+        auth=(mock_user, mock_pass),
     )
     mock_response = mock_requests.post.return_value
     mock_response.raise_for_status.assert_called_once()
@@ -72,7 +70,9 @@ def test_post_to_influxdb_empty_string(mock_requests):
     """
     tests post_to_influxdb function when datastring is empty, should do nothing
     """
-    post_to_influxdb("", NonCallableMock(), NonCallableMock(), (NonCallableMock(), NonCallableMock()))
+    post_to_influxdb(
+        "", NonCallableMock(), NonCallableMock(), (NonCallableMock(), NonCallableMock())
+    )
     mock_requests.post.assert_not_called()
 
 
@@ -131,12 +131,14 @@ def test_run_scrape(mock_post_to_influxdb):
         "auth.username": mock_user,
         "cloud.instance": mock_instance,
         "db.database": mock_db,
-        "db.host": mock_host
+        "db.host": mock_host,
     }
     mock_scrape_func = MagicMock()
 
     run_scrape(mock_influxdb_args, mock_scrape_func)
     mock_post_to_influxdb.assert_called_once_with(
         mock_scrape_func.return_value,
-        host=mock_host, db_name=mock_db, auth=(mock_user, mock_pass)
+        host=mock_host,
+        db_name=mock_db,
+        auth=(mock_user, mock_pass),
     )

--- a/MonitoringTools/tests/test_send_metric_utils.py
+++ b/MonitoringTools/tests/test_send_metric_utils.py
@@ -1,0 +1,142 @@
+import configparser
+from pathlib import Path
+from unittest.mock import patch, call, NonCallableMock, MagicMock
+
+import pytest
+
+from send_metric_utils import read_config_file, post_to_influxdb, parse_args, run_scrape
+
+
+@patch("send_metric_utils.ConfigParser")
+def test_read_config_file_valid(mock_config_parser):
+    """
+    tests read_config_file function when given a valid config file
+    """
+    mock_config_obj = mock_config_parser.return_value
+    mock_config_obj.sections.return_value = ["auth", "cloud", "db"]
+    mock_config_obj.items.side_effect = [
+        [("password", "pass"), ("username", "user")],
+        [("instance", "prod")],
+        [("database", "cloud"), ("host", "localhost:8086")]
+    ]
+    mock_filepath = NonCallableMock()
+    res = read_config_file(mock_filepath)
+    mock_config_parser.assert_called_once()
+    mock_config_obj.sections.assert_called_once()
+    mock_config_obj.items.assert_has_calls([
+        call("auth"), call("cloud"), call("db")
+    ])
+
+    assert res == {
+        "auth.password": "pass",
+        "auth.username": "user",
+        "cloud.instance": "prod",
+        "db.database": "cloud",
+        "db.host": "localhost:8086"
+    }
+
+
+@patch("send_metric_utils.ConfigParser")
+def test_read_config_file_empty(mock_config_parser):
+    """
+    tests read_config_file function when given a emtpy config file
+    """
+    mock_config_parser.return_value.sections.return_value = []
+    with pytest.raises(AssertionError):
+        read_config_file(NonCallableMock())
+
+
+@patch("send_metric_utils.requests")
+def test_post_to_influxdb_valid(mock_requests):
+    """
+    tests post_to_influxdb function uses requests.post to post data correctly
+    """
+    mock_data_string = NonCallableMock()
+    mock_host = "localhost:8086"
+    mock_db_name = "cloud"
+    mock_pass = NonCallableMock()
+    mock_user = NonCallableMock()
+
+    post_to_influxdb(mock_data_string, mock_host, mock_db_name, (mock_user, mock_pass))
+    mock_requests.post.assert_called_once_with(
+        "http://localhost:8086/write?db=cloud&precision=s",
+        data=mock_data_string,
+        auth=(mock_user, mock_pass)
+    )
+    mock_response = mock_requests.post.return_value
+    mock_response.raise_for_status.assert_called_once()
+
+
+@patch("send_metric_utils.requests")
+def test_post_to_influxdb_empty_string(mock_requests):
+    """
+    tests post_to_influxdb function when datastring is empty, should do nothing
+    """
+    post_to_influxdb("", NonCallableMock(), NonCallableMock(), (NonCallableMock(), NonCallableMock()))
+    mock_requests.post.assert_not_called()
+
+
+@patch("send_metric_utils.read_config_file")
+def test_parse_args_valid_args(mock_read_config_file):
+    """
+    tests parse_args function with a valid filepath
+    """
+    res = parse_args(["../usr/local/bin/influxdb.conf"])
+    assert res == mock_read_config_file.return_value
+
+
+def test_parse_args_filepath_does_not_exist():
+    """
+    tests parse_args function with invalid filepath (doesn't exist)
+    """
+    with pytest.raises(RuntimeError):
+        parse_args(["./invalid-filepath"])
+
+
+def test_parse_args_filepath_invalid_dir_fp():
+    """
+    tests parse_args function with invalid filepath (points to directory)
+    """
+    with pytest.raises(RuntimeError):
+        parse_args(["."])
+
+
+@patch("send_metric_utils.read_config_file")
+def test_parse_args_filepath_read_config_fails(mock_read_config_file):
+    """
+    tests parse_args function fails when read_config_file returns config error
+    """
+    mock_read_config_file.side_effect = configparser.Error
+    with pytest.raises(RuntimeError):
+        parse_args(["../usr/local/bin/influxdb.conf"])
+
+    mock_read_config_file.assert_called_once_with(
+        Path("../usr/local/bin/influxdb.conf")
+    )
+
+
+@patch("send_metric_utils.post_to_influxdb")
+def test_run_scrape(mock_post_to_influxdb):
+    """
+    Tests run_scrape function.
+    """
+    mock_pass = NonCallableMock()
+    mock_user = NonCallableMock()
+    mock_host = NonCallableMock()
+    mock_db = NonCallableMock()
+    mock_instance = NonCallableMock()
+
+    mock_influxdb_args = {
+        "auth.password": mock_pass,
+        "auth.username": mock_user,
+        "cloud.instance": mock_instance,
+        "db.database": mock_db,
+        "db.host": mock_host
+    }
+    mock_scrape_func = MagicMock()
+
+    run_scrape(mock_influxdb_args, mock_scrape_func)
+    mock_post_to_influxdb.assert_called_once_with(
+        mock_scrape_func.return_value,
+        host=mock_host, db_name=mock_db, auth=(mock_user, mock_pass)
+    )

--- a/MonitoringTools/tests/test_service_status_to_influx.py
+++ b/MonitoringTools/tests/test_service_status_to_influx.py
@@ -1,0 +1,380 @@
+from unittest.mock import patch, call, NonCallableMock, MagicMock
+import pytest
+
+from service_status_to_influx import (
+    get_hypervisor_properties,
+    get_service_properties,
+    get_agent_properties,
+    convert_to_data_string,
+    get_service_prop_string,
+    get_all_hv_details,
+    update_with_service_statuses,
+    update_with_agent_statuses,
+    get_all_service_statuses,
+    main
+)
+
+
+def test_get_hypervisor_properties_state_up():
+    mock_hv = {
+        "state": "up",
+        "memory_size": 1,
+        "memory_used": 2,
+        "memory_free": 3,
+        "vcpus_used": 4,
+        "vcpus": 5,
+    }
+    expected_result = {"hv": {
+        "aggregate": "no-aggregate",
+        "memorymax": 1,
+        "memoryused": 2,
+        "memoryavailable": 3,
+        "cpuused": 4,
+        "cpumax": 5,
+        "cpuavailable": 1,
+        "agent": 1,
+        "state": 1,
+        "statetext": "Up"
+    }}
+    assert get_hypervisor_properties(mock_hv) == expected_result
+
+
+def test_get_hypervisor_properties_state_down():
+    mock_hv = {
+        "state": "down",
+        "memory_size": 1,
+        "memory_used": 2,
+        "memory_free": 3,
+        "vcpus_used": 4,
+        "vcpus": 5,
+    }
+    expected_result = {"hv": {
+        "aggregate": "no-aggregate",
+        "memorymax": 1,
+        "memoryused": 2,
+        "memoryavailable": 3,
+        "cpuused": 4,
+        "cpumax": 5,
+        "cpuavailable": 1,
+        "agent": 1,
+        "state": 0,
+        "statetext": "Down"
+    }}
+    assert get_hypervisor_properties(mock_hv) == expected_result
+
+
+def test_get_service_properties_enabled_up():
+    mock_service = {
+        "binary": "foo",
+        "status": "enabled",
+        "state": "up"
+    }
+    expected_result = {
+        "foo": {
+            "status": 1,
+            "statustext": "Enabled",
+            "state": 1,
+            "statetext": "Up",
+            "agent": 1
+        }
+    }
+    assert get_service_properties(mock_service) == expected_result
+
+
+def test_get_service_properties_disabled_down():
+    mock_service = {
+        "binary": "bar",
+        "status": "disabled",
+        "state": "down"
+    }
+    expected_result = {
+        "bar": {
+            "status": 0,
+            "statustext": "Disabled",
+            "state": 0,
+            "statetext": "Down",
+            "agent": 1
+        }
+    }
+    assert get_service_properties(mock_service) == expected_result
+
+
+def test_get_agent_properties_alive_admin_up():
+    mock_agent = {
+        "binary": "foo",
+        "is_alive": True,
+        "is_admin_state_up": True,
+    }
+    expected_result = {
+        "foo": {
+            "state": 1,
+            "statetext": "Up",
+            "status": 1,
+            "statustext": "Enabled",
+            "agent": 1
+        }
+    }
+    assert get_agent_properties(mock_agent) == expected_result
+
+
+def test_get_agent_properties_disabled_down():
+    mock_agent = {
+        "binary": "bar",
+        "is_alive": False,
+        "is_admin_state_up": False,
+    }
+    expected_result = {
+        "bar": {
+            "state": 0,
+            "statetext": "Down",
+            "status": 0,
+            "statustext": "Disabled",
+            "agent": 1
+        }
+    }
+    assert get_agent_properties(mock_agent) == expected_result
+
+
+def test_convert_to_data_string_no_items():
+    """
+    Tests convert_to_data_string returns empty string when given no details
+    """
+    assert convert_to_data_string(NonCallableMock(), {}) == ""
+
+
+@patch("service_status_to_influx.get_service_prop_string")
+def test_convert_to_data_string_one_hv_one_service(mock_get_service_prop_string):
+    """
+    Tests convert_to_data_string works with single entry in details
+    """
+    mock_instance = "prod"
+    mock_service_details = NonCallableMock()
+    mock_details = {"hv1": {"service1": mock_service_details}}
+
+    mock_get_service_prop_string.return_value = "prop1=val1"
+
+    res = convert_to_data_string(mock_instance, mock_details)
+    assert res == 'ServiceStatus,host="hv1",service="service1",instance=Prod prop1=val1'
+    mock_get_service_prop_string.assert_called_once_with(mock_service_details)
+
+
+@patch("service_status_to_influx.get_service_prop_string")
+def test_convert_to_data_string_one_hv_multi_service(mock_get_service_prop_string):
+    """
+    Tests convert_to_data_string works with single entry in details with multiple service binaries
+    """
+    mock_instance = "prod"
+    mock_service_details_1 = NonCallableMock()
+    mock_service_details_2 = NonCallableMock()
+    mock_details = {"hv1": {
+        "service1": mock_service_details_1,
+        "service2": mock_service_details_2
+    }}
+
+    mock_get_service_prop_string.side_effect = ["prop1=val1", "prop1=val2"]
+
+    res = convert_to_data_string(mock_instance, mock_details)
+    assert res == (
+        'ServiceStatus,host="hv1",service="service1",instance=Prod prop1=val1'
+        'ServiceStatus,host="hv1",service="service2",instance=Prod prop1=val2'
+    )
+    mock_get_service_prop_string.assert_has_calls([
+        call(mock_service_details_1), call(mock_service_details_2)
+    ])
+
+
+@patch("service_status_to_influx.get_service_prop_string")
+def test_convert_to_data_string_multi_item(mock_get_service_prop_string):
+    """
+    Tests convert_to_data_string works with multiple entries in dict for details
+    """
+    mock_instance = "prod"
+    mock_service_details_1 = NonCallableMock()
+    mock_service_details_2 = NonCallableMock()
+    mock_service_details_3 = NonCallableMock()
+    mock_details = {
+        "hv1": {
+            "service1": mock_service_details_1,
+            "service2": mock_service_details_2,
+        },
+        "hv2": {
+            "service3": mock_service_details_3
+        }
+    }
+
+    mock_get_service_prop_string.side_effect = [
+        "prop1=val1", "prop1=val2", "prop1=val3"
+    ]
+
+    res = convert_to_data_string(mock_instance, mock_details)
+    assert res == (
+        'ServiceStatus,host="hv1",service="service1",instance=Prod prop1=val1'
+        'ServiceStatus,host="hv1",service="service2",instance=Prod prop1=val2'
+        'ServiceStatus,host="hv2",service="service3",instance=Prod prop1=val3'
+    )
+    mock_get_service_prop_string.assert_has_calls([
+        call(mock_service_details_1), call(mock_service_details_2), call(mock_service_details_3)
+    ])
+
+
+def test_get_service_prop_string_empty_dict():
+    props = {}
+    expected_result = ''
+    assert get_service_prop_string(props) == expected_result
+
+
+def test_get_service_prop_string_with_string_props():
+    props = {"statetext": "foo", "statustext": "bar", "aggregate": "baz"}
+    expected_result = 'statetext="foo",statustext="bar",aggregate="baz"'
+    assert get_service_prop_string(props) == expected_result
+
+
+def test_get_service_prop_string_with_int_props():
+    props = {"prop1": 1, "prop2": 2, "prop3": 3}
+    expected_result = 'prop1="1i",prop2="2i",prop3="3i"'
+    assert get_service_prop_string(props) == expected_result
+
+
+@patch("service_status_to_influx.get_hypervisor_properties")
+def test_get_all_hv_details(mock_get_hypervisor_properties):
+    mock_conn = MagicMock()
+    mock_hvs = [{"name": "hv1"}, {"name": "hv2"}, {"name": "hv3"}]
+
+    mock_aggregates = [
+        {"name": "ag1", "hosts": ["hv1", "hv2"]},
+        {"name": "ag2", "hosts": ["hv3", "hv4"]},
+        {"name": "ag3", "hosts": ["hv5"]},
+    ]
+
+    # stubs out getting props
+    mock_get_hypervisor_properties.side_effect = [
+        {"hv": {}}, {"hv": {}}, {"hv": {}}
+    ]
+    mock_conn.list_hypervisors.return_value = mock_hvs
+    mock_conn.compute.aggregates.return_value = mock_aggregates
+    res = get_all_hv_details(mock_conn)
+
+    mock_conn.list_hypervisors.assert_called_once()
+    mock_conn.compute.aggregates.assert_called_once()
+
+    mock_get_hypervisor_properties.assert_has_calls(
+        [call(hv) for hv in mock_hvs]
+    )
+
+    assert res == {
+        "hv1": {"hv": {"aggregate": "ag1"}},
+        "hv2": {"hv": {"aggregate": "ag1"}},
+        "hv3": {"hv": {"aggregate": "ag2"}}
+    }
+
+
+@patch("service_status_to_influx.get_service_properties")
+def test_update_with_service_statuses(mock_get_service_properties):
+    mock_conn = MagicMock()
+    mock_status_details = {
+        "hv1": {"hv": {}, "foo": {}, "bar": {}},
+        "hv2": {"hv": {}},
+    }
+
+    mock_services = [
+        {"host": "hv1", "binary": "nova-compute"},
+        {"host": "hv1", "binary": "other-svc"},
+        {"host": "hv2", "binary": "other-svc"},
+        {"host": "hv3", "binary": "nova-compute"},
+    ]
+    mock_conn.compute.services.return_value = mock_services
+
+    # stubs out actually getting properties
+    mock_get_service_properties.side_effect = [
+        {"nova-compute": {"status": "enabled"}},
+        {"other-service": {}},
+        {"other-service": {"status": "enabled"}},
+        {"nova-compute": {"status": "disabled"}}
+    ]
+
+    res = update_with_service_statuses(mock_conn, mock_status_details)
+
+    mock_conn.compute.services.assert_called_once()
+    mock_get_service_properties.assert_has_calls(
+        [call(svc) for svc in mock_services]
+    )
+    assert res == {
+        # shouldn't override what's already there
+        # add hv status == nova-compute svc status
+        "hv1": {
+            "hv": {"status": "enabled"},
+            "nova-compute": {"status": "enabled"},
+            "foo": {}, "bar": {},
+            "other-service": {}
+        },
+        # only nova-compute status adds hv status
+        "hv2": {
+            "hv": {},
+            "other-service": {"status": "enabled"}
+        },
+        # adds what doesn't exist, no "hv" so no setting status
+        "hv3": {"nova-compute": {"status": "disabled"}}
+    }
+
+
+@patch("service_status_to_influx.get_agent_properties")
+def test_update_with_agent_statuses(mock_get_agent_properties):
+    mock_conn = MagicMock()
+    mock_status_details = {"hv1": {"foo": {}}, "hv2": {}}
+
+    mock_agents = [
+        {"host": "hv1", "binary": "ag1"},
+        {"host": "hv1", "binary": "ag2"},
+        {"host": "hv2", "binary": "ag1"},
+        {"host": "hv3", "binary": "ag3"}
+    ]
+    mock_conn.network.agents.return_value = mock_agents
+
+    # stubs out actually getting properties
+    mock_get_agent_properties.side_effect = [
+        {"ag1": {}}, {"ag2": {}}, {"ag1": {}}, {"ag3": {}},
+    ]
+
+    res = update_with_agent_statuses(mock_conn, mock_status_details)
+
+    mock_conn.network.agents.assert_called_once()
+    mock_get_agent_properties.assert_has_calls([call(agent) for agent in mock_agents])
+    assert res == {
+        # shouldn't override what's already there
+        "hv1": {"foo": {}, "ag1": {}, "ag2": {}},
+        "hv2": {"ag1": {}},
+        # adds what doesn't exist
+        "hv3": {"ag3": {}}
+    }
+
+
+@patch("service_status_to_influx.openstack")
+@patch("service_status_to_influx.get_all_hv_details")
+@patch("service_status_to_influx.update_with_service_statuses")
+@patch("service_status_to_influx.update_with_agent_statuses")
+@patch("service_status_to_influx.convert_to_data_string")
+def test_get_all_service_statuses(
+    mock_convert,
+    mock_get_agent_statuses,
+    mock_get_service_statuses,
+    mock_get_hv_statuses,
+    mock_openstack
+):
+    mock_instance = NonCallableMock()
+    mock_conn = mock_openstack.connect.return_value
+    res = get_all_service_statuses(mock_instance)
+    mock_openstack.connect.assert_called_once_with(mock_instance)
+    mock_get_hv_statuses.assert_called_once_with(mock_conn)
+    mock_get_service_statuses.assert_called_once_with(mock_conn, mock_get_hv_statuses.return_value)
+    mock_get_agent_statuses.assert_called_once_with(mock_conn, mock_get_service_statuses.return_value)
+    mock_convert.assert_called_once_with(mock_instance, mock_get_agent_statuses.return_value)
+    assert res == mock_convert.return_value
+
+
+@patch("service_status_to_influx.run_scrape")
+@patch("service_status_to_influx.parse_args")
+def test_main(mock_parse_args, mock_run_scrape):
+    mock_user_args = NonCallableMock()
+    main(mock_user_args)
+    mock_run_scrape.assert_called_once_with(mock_parse_args.return_value, get_all_service_statuses)
+    mock_parse_args.assert_called_once_with(mock_user_args, description="Get All Service Statuses")

--- a/MonitoringTools/tests/test_service_status_to_influx.py
+++ b/MonitoringTools/tests/test_service_status_to_influx.py
@@ -150,7 +150,9 @@ def test_convert_to_data_string_one_hv_one_service(mock_get_service_prop_string)
     mock_get_service_prop_string.return_value = "prop1=val1"
 
     res = convert_to_data_string(mock_instance, mock_details)
-    assert res == 'ServiceStatus,host="hv1",service="service1",instance=Prod prop1=val1'
+    assert (
+        res == 'ServiceStatus,host="hv1",service="service1",instance=Prod prop1=val1\n'
+    )
     mock_get_service_prop_string.assert_called_once_with(mock_service_details)
 
 
@@ -170,8 +172,8 @@ def test_convert_to_data_string_one_hv_multi_service(mock_get_service_prop_strin
 
     res = convert_to_data_string(mock_instance, mock_details)
     assert res == (
-        'ServiceStatus,host="hv1",service="service1",instance=Prod prop1=val1'
-        'ServiceStatus,host="hv1",service="service2",instance=Prod prop1=val2'
+        'ServiceStatus,host="hv1",service="service1",instance=Prod prop1=val1\n'
+        'ServiceStatus,host="hv1",service="service2",instance=Prod prop1=val2\n'
     )
     mock_get_service_prop_string.assert_has_calls(
         [call(mock_service_details_1), call(mock_service_details_2)]
@@ -203,9 +205,9 @@ def test_convert_to_data_string_multi_item(mock_get_service_prop_string):
 
     res = convert_to_data_string(mock_instance, mock_details)
     assert res == (
-        'ServiceStatus,host="hv1",service="service1",instance=Prod prop1=val1'
-        'ServiceStatus,host="hv1",service="service2",instance=Prod prop1=val2'
-        'ServiceStatus,host="hv2",service="service3",instance=Prod prop1=val3'
+        'ServiceStatus,host="hv1",service="service1",instance=Prod prop1=val1\n'
+        'ServiceStatus,host="hv1",service="service2",instance=Prod prop1=val2\n'
+        'ServiceStatus,host="hv2",service="service3",instance=Prod prop1=val3\n'
     )
     mock_get_service_prop_string.assert_has_calls(
         [

--- a/MonitoringTools/tests/test_service_status_to_influx.py
+++ b/MonitoringTools/tests/test_service_status_to_influx.py
@@ -16,6 +16,10 @@ from service_status_to_influx import (
 
 
 def test_get_hypervisor_properties_state_up():
+    """
+    tests that get_hypervisor_properties parses a valid hypervisor entry properly and extracts
+    useful information and returns the result in correct format - when hv state is up
+    """
     mock_hv = {
         "state": "up",
         "memory_size": 1,
@@ -42,6 +46,11 @@ def test_get_hypervisor_properties_state_up():
 
 
 def test_get_hypervisor_properties_state_down():
+    """
+    tests that get_hypervisor_properties parses a valid hypervisor entry properly and extracts
+    useful information and returns the result in correct format - when hv state is down
+    :return:
+    """
     mock_hv = {
         "state": "down",
         "memory_size": 1,
@@ -68,6 +77,10 @@ def test_get_hypervisor_properties_state_down():
 
 
 def test_get_service_properties_enabled_up():
+    """
+    tests that get_service_properties parses a valid service entry properly and extracts
+    useful information and returns the result in correct format - when status=enabled, state=up
+    """
     mock_service = {"binary": "foo", "status": "enabled", "state": "up"}
     expected_result = {
         "foo": {
@@ -82,6 +95,10 @@ def test_get_service_properties_enabled_up():
 
 
 def test_get_service_properties_disabled_down():
+    """
+    tests that get_service_properties parses a valid service entry properly and extracts
+    useful information and returns the result in correct format - when status=disabled, state=down
+    """
     mock_service = {"binary": "bar", "status": "disabled", "state": "down"}
     expected_result = {
         "bar": {
@@ -96,6 +113,11 @@ def test_get_service_properties_disabled_down():
 
 
 def test_get_agent_properties_alive_admin_up():
+    """
+    tests that get_agent_properties parses a valid network agent entry properly and extracts
+    useful information and returns the result in correct format
+    - when is_alive=True, is_admin_state_up=True
+    """
     mock_agent = {
         "binary": "foo",
         "is_alive": True,
@@ -114,6 +136,11 @@ def test_get_agent_properties_alive_admin_up():
 
 
 def test_get_agent_properties_disabled_down():
+    """
+    tests that get_agent_properties parses a valid network agent entry properly and extracts
+    useful information and returns the result in correct format
+    - when is_alive=False, is_admin_state_up=False
+    """
     mock_agent = {
         "binary": "bar",
         "is_alive": False,
@@ -219,18 +246,27 @@ def test_convert_to_data_string_multi_item(mock_get_service_prop_string):
 
 
 def test_get_service_prop_string_empty_dict():
-    props = {}
-    expected_result = ""
-    assert get_service_prop_string(props) == expected_result
+    """
+    tests get_service_prop_string returns nothing when given empty service_dict
+    """
+    assert get_service_prop_string({}) == ""
 
 
 def test_get_service_prop_string_with_string_props():
+    """
+    tests get_service_prop_string returns correct prop string
+    when given string props it should not suffix each property value with i
+    """
     props = {"statetext": "foo", "statustext": "bar", "aggregate": "baz"}
     expected_result = 'statetext="foo",statustext="bar",aggregate="baz"'
     assert get_service_prop_string(props) == expected_result
 
 
 def test_get_service_prop_string_with_int_props():
+    """
+    tests get_service_prop_string returns correct prop string
+    when given int props it should suffix each property value with i
+    """
     props = {"prop1": 1, "prop2": 2, "prop3": 3}
     expected_result = 'prop1="1i",prop2="2i",prop3="3i"'
     assert get_service_prop_string(props) == expected_result
@@ -238,6 +274,12 @@ def test_get_service_prop_string_with_int_props():
 
 @patch("service_status_to_influx.get_hypervisor_properties")
 def test_get_all_hv_details(mock_get_hypervisor_properties):
+    """
+    tests get_all_hv_details returns dict of hypervisor status information
+    - for each hypervisor, call get_hypervisor_properties and store in a dict,
+    - then for each aggregate update the aggregate property for each hv with the aggregate name
+        that the hv belongs to
+    """
     mock_conn = MagicMock()
     mock_hvs = [{"name": "hv1"}, {"name": "hv2"}, {"name": "hv3"}]
 
@@ -267,6 +309,10 @@ def test_get_all_hv_details(mock_get_hypervisor_properties):
 
 @patch("service_status_to_influx.get_service_properties")
 def test_update_with_service_statuses(mock_get_service_properties):
+    """
+    tests update_with_service_statuses, for each service found, get its properties
+    and update provided dictionary status_details dict with service info
+    """
     mock_conn = MagicMock()
     mock_status_details = {
         "hv1": {"hv": {}, "foo": {}, "bar": {}},
@@ -312,6 +358,10 @@ def test_update_with_service_statuses(mock_get_service_properties):
 
 @patch("service_status_to_influx.get_agent_properties")
 def test_update_with_agent_statuses(mock_get_agent_properties):
+    """
+    tests update_with_agent_statuses, for each network agent found, get its properties
+    and update provided dictionary status_details dict with agent info
+    """
     mock_conn = MagicMock()
     mock_status_details = {"hv1": {"foo": {}}, "hv2": {}}
 
@@ -356,6 +406,13 @@ def test_get_all_service_statuses(
     mock_get_hv_statuses,
     mock_openstack,
 ):
+    """
+    Tests get_all_service_statuses calls appropriate functions:
+    - get hv status info
+    - update with service status info
+    - update with agent status info
+    - calls convert_to_data_string on result and output
+    """
     mock_instance = NonCallableMock()
     mock_conn = mock_openstack.connect.return_value
     res = get_all_service_statuses(mock_instance)
@@ -376,6 +433,9 @@ def test_get_all_service_statuses(
 @patch("service_status_to_influx.run_scrape")
 @patch("service_status_to_influx.parse_args")
 def test_main(mock_parse_args, mock_run_scrape):
+    """
+    tests main function calls run_scrape utility function properly
+    """
     mock_user_args = NonCallableMock()
     main(mock_user_args)
     mock_run_scrape.assert_called_once_with(

--- a/MonitoringTools/tests/test_service_status_to_influx.py
+++ b/MonitoringTools/tests/test_service_status_to_influx.py
@@ -11,7 +11,7 @@ from service_status_to_influx import (
     update_with_service_statuses,
     update_with_agent_statuses,
     get_all_service_statuses,
-    main
+    main,
 )
 
 
@@ -24,18 +24,20 @@ def test_get_hypervisor_properties_state_up():
         "vcpus_used": 4,
         "vcpus": 5,
     }
-    expected_result = {"hv": {
-        "aggregate": "no-aggregate",
-        "memorymax": 1,
-        "memoryused": 2,
-        "memoryavailable": 3,
-        "cpuused": 4,
-        "cpumax": 5,
-        "cpuavailable": 1,
-        "agent": 1,
-        "state": 1,
-        "statetext": "Up"
-    }}
+    expected_result = {
+        "hv": {
+            "aggregate": "no-aggregate",
+            "memorymax": 1,
+            "memoryused": 2,
+            "memoryavailable": 3,
+            "cpuused": 4,
+            "cpumax": 5,
+            "cpuavailable": 1,
+            "agent": 1,
+            "state": 1,
+            "statetext": "Up",
+        }
+    }
     assert get_hypervisor_properties(mock_hv) == expected_result
 
 
@@ -48,52 +50,46 @@ def test_get_hypervisor_properties_state_down():
         "vcpus_used": 4,
         "vcpus": 5,
     }
-    expected_result = {"hv": {
-        "aggregate": "no-aggregate",
-        "memorymax": 1,
-        "memoryused": 2,
-        "memoryavailable": 3,
-        "cpuused": 4,
-        "cpumax": 5,
-        "cpuavailable": 1,
-        "agent": 1,
-        "state": 0,
-        "statetext": "Down"
-    }}
+    expected_result = {
+        "hv": {
+            "aggregate": "no-aggregate",
+            "memorymax": 1,
+            "memoryused": 2,
+            "memoryavailable": 3,
+            "cpuused": 4,
+            "cpumax": 5,
+            "cpuavailable": 1,
+            "agent": 1,
+            "state": 0,
+            "statetext": "Down",
+        }
+    }
     assert get_hypervisor_properties(mock_hv) == expected_result
 
 
 def test_get_service_properties_enabled_up():
-    mock_service = {
-        "binary": "foo",
-        "status": "enabled",
-        "state": "up"
-    }
+    mock_service = {"binary": "foo", "status": "enabled", "state": "up"}
     expected_result = {
         "foo": {
             "status": 1,
             "statustext": "Enabled",
             "state": 1,
             "statetext": "Up",
-            "agent": 1
+            "agent": 1,
         }
     }
     assert get_service_properties(mock_service) == expected_result
 
 
 def test_get_service_properties_disabled_down():
-    mock_service = {
-        "binary": "bar",
-        "status": "disabled",
-        "state": "down"
-    }
+    mock_service = {"binary": "bar", "status": "disabled", "state": "down"}
     expected_result = {
         "bar": {
             "status": 0,
             "statustext": "Disabled",
             "state": 0,
             "statetext": "Down",
-            "agent": 1
+            "agent": 1,
         }
     }
     assert get_service_properties(mock_service) == expected_result
@@ -111,7 +107,7 @@ def test_get_agent_properties_alive_admin_up():
             "statetext": "Up",
             "status": 1,
             "statustext": "Enabled",
-            "agent": 1
+            "agent": 1,
         }
     }
     assert get_agent_properties(mock_agent) == expected_result
@@ -129,7 +125,7 @@ def test_get_agent_properties_disabled_down():
             "statetext": "Down",
             "status": 0,
             "statustext": "Disabled",
-            "agent": 1
+            "agent": 1,
         }
     }
     assert get_agent_properties(mock_agent) == expected_result
@@ -166,10 +162,9 @@ def test_convert_to_data_string_one_hv_multi_service(mock_get_service_prop_strin
     mock_instance = "prod"
     mock_service_details_1 = NonCallableMock()
     mock_service_details_2 = NonCallableMock()
-    mock_details = {"hv1": {
-        "service1": mock_service_details_1,
-        "service2": mock_service_details_2
-    }}
+    mock_details = {
+        "hv1": {"service1": mock_service_details_1, "service2": mock_service_details_2}
+    }
 
     mock_get_service_prop_string.side_effect = ["prop1=val1", "prop1=val2"]
 
@@ -178,9 +173,9 @@ def test_convert_to_data_string_one_hv_multi_service(mock_get_service_prop_strin
         'ServiceStatus,host="hv1",service="service1",instance=Prod prop1=val1'
         'ServiceStatus,host="hv1",service="service2",instance=Prod prop1=val2'
     )
-    mock_get_service_prop_string.assert_has_calls([
-        call(mock_service_details_1), call(mock_service_details_2)
-    ])
+    mock_get_service_prop_string.assert_has_calls(
+        [call(mock_service_details_1), call(mock_service_details_2)]
+    )
 
 
 @patch("service_status_to_influx.get_service_prop_string")
@@ -197,13 +192,13 @@ def test_convert_to_data_string_multi_item(mock_get_service_prop_string):
             "service1": mock_service_details_1,
             "service2": mock_service_details_2,
         },
-        "hv2": {
-            "service3": mock_service_details_3
-        }
+        "hv2": {"service3": mock_service_details_3},
     }
 
     mock_get_service_prop_string.side_effect = [
-        "prop1=val1", "prop1=val2", "prop1=val3"
+        "prop1=val1",
+        "prop1=val2",
+        "prop1=val3",
     ]
 
     res = convert_to_data_string(mock_instance, mock_details)
@@ -212,14 +207,18 @@ def test_convert_to_data_string_multi_item(mock_get_service_prop_string):
         'ServiceStatus,host="hv1",service="service2",instance=Prod prop1=val2'
         'ServiceStatus,host="hv2",service="service3",instance=Prod prop1=val3'
     )
-    mock_get_service_prop_string.assert_has_calls([
-        call(mock_service_details_1), call(mock_service_details_2), call(mock_service_details_3)
-    ])
+    mock_get_service_prop_string.assert_has_calls(
+        [
+            call(mock_service_details_1),
+            call(mock_service_details_2),
+            call(mock_service_details_3),
+        ]
+    )
 
 
 def test_get_service_prop_string_empty_dict():
     props = {}
-    expected_result = ''
+    expected_result = ""
     assert get_service_prop_string(props) == expected_result
 
 
@@ -247,9 +246,7 @@ def test_get_all_hv_details(mock_get_hypervisor_properties):
     ]
 
     # stubs out getting props
-    mock_get_hypervisor_properties.side_effect = [
-        {"hv": {}}, {"hv": {}}, {"hv": {}}
-    ]
+    mock_get_hypervisor_properties.side_effect = [{"hv": {}}, {"hv": {}}, {"hv": {}}]
     mock_conn.list_hypervisors.return_value = mock_hvs
     mock_conn.compute.aggregates.return_value = mock_aggregates
     res = get_all_hv_details(mock_conn)
@@ -257,14 +254,12 @@ def test_get_all_hv_details(mock_get_hypervisor_properties):
     mock_conn.list_hypervisors.assert_called_once()
     mock_conn.compute.aggregates.assert_called_once()
 
-    mock_get_hypervisor_properties.assert_has_calls(
-        [call(hv) for hv in mock_hvs]
-    )
+    mock_get_hypervisor_properties.assert_has_calls([call(hv) for hv in mock_hvs])
 
     assert res == {
         "hv1": {"hv": {"aggregate": "ag1"}},
         "hv2": {"hv": {"aggregate": "ag1"}},
-        "hv3": {"hv": {"aggregate": "ag2"}}
+        "hv3": {"hv": {"aggregate": "ag2"}},
     }
 
 
@@ -289,31 +284,27 @@ def test_update_with_service_statuses(mock_get_service_properties):
         {"nova-compute": {"status": "enabled"}},
         {"other-service": {}},
         {"other-service": {"status": "enabled"}},
-        {"nova-compute": {"status": "disabled"}}
+        {"nova-compute": {"status": "disabled"}},
     ]
 
     res = update_with_service_statuses(mock_conn, mock_status_details)
 
     mock_conn.compute.services.assert_called_once()
-    mock_get_service_properties.assert_has_calls(
-        [call(svc) for svc in mock_services]
-    )
+    mock_get_service_properties.assert_has_calls([call(svc) for svc in mock_services])
     assert res == {
         # shouldn't override what's already there
         # add hv status == nova-compute svc status
         "hv1": {
             "hv": {"status": "enabled"},
             "nova-compute": {"status": "enabled"},
-            "foo": {}, "bar": {},
-            "other-service": {}
+            "foo": {},
+            "bar": {},
+            "other-service": {},
         },
         # only nova-compute status adds hv status
-        "hv2": {
-            "hv": {},
-            "other-service": {"status": "enabled"}
-        },
+        "hv2": {"hv": {}, "other-service": {"status": "enabled"}},
         # adds what doesn't exist, no "hv" so no setting status
-        "hv3": {"nova-compute": {"status": "disabled"}}
+        "hv3": {"nova-compute": {"status": "disabled"}},
     }
 
 
@@ -326,13 +317,16 @@ def test_update_with_agent_statuses(mock_get_agent_properties):
         {"host": "hv1", "binary": "ag1"},
         {"host": "hv1", "binary": "ag2"},
         {"host": "hv2", "binary": "ag1"},
-        {"host": "hv3", "binary": "ag3"}
+        {"host": "hv3", "binary": "ag3"},
     ]
     mock_conn.network.agents.return_value = mock_agents
 
     # stubs out actually getting properties
     mock_get_agent_properties.side_effect = [
-        {"ag1": {}}, {"ag2": {}}, {"ag1": {}}, {"ag3": {}},
+        {"ag1": {}},
+        {"ag2": {}},
+        {"ag1": {}},
+        {"ag3": {}},
     ]
 
     res = update_with_agent_statuses(mock_conn, mock_status_details)
@@ -344,7 +338,7 @@ def test_update_with_agent_statuses(mock_get_agent_properties):
         "hv1": {"foo": {}, "ag1": {}, "ag2": {}},
         "hv2": {"ag1": {}},
         # adds what doesn't exist
-        "hv3": {"ag3": {}}
+        "hv3": {"ag3": {}},
     }
 
 
@@ -358,16 +352,22 @@ def test_get_all_service_statuses(
     mock_get_agent_statuses,
     mock_get_service_statuses,
     mock_get_hv_statuses,
-    mock_openstack
+    mock_openstack,
 ):
     mock_instance = NonCallableMock()
     mock_conn = mock_openstack.connect.return_value
     res = get_all_service_statuses(mock_instance)
     mock_openstack.connect.assert_called_once_with(mock_instance)
     mock_get_hv_statuses.assert_called_once_with(mock_conn)
-    mock_get_service_statuses.assert_called_once_with(mock_conn, mock_get_hv_statuses.return_value)
-    mock_get_agent_statuses.assert_called_once_with(mock_conn, mock_get_service_statuses.return_value)
-    mock_convert.assert_called_once_with(mock_instance, mock_get_agent_statuses.return_value)
+    mock_get_service_statuses.assert_called_once_with(
+        mock_conn, mock_get_hv_statuses.return_value
+    )
+    mock_get_agent_statuses.assert_called_once_with(
+        mock_conn, mock_get_service_statuses.return_value
+    )
+    mock_convert.assert_called_once_with(
+        mock_instance, mock_get_agent_statuses.return_value
+    )
     assert res == mock_convert.return_value
 
 
@@ -376,5 +376,9 @@ def test_get_all_service_statuses(
 def test_main(mock_parse_args, mock_run_scrape):
     mock_user_args = NonCallableMock()
     main(mock_user_args)
-    mock_run_scrape.assert_called_once_with(mock_parse_args.return_value, get_all_service_statuses)
-    mock_parse_args.assert_called_once_with(mock_user_args, description="Get All Service Statuses")
+    mock_run_scrape.assert_called_once_with(
+        mock_parse_args.return_value, get_all_service_statuses
+    )
+    mock_parse_args.assert_called_once_with(
+        mock_user_args, description="Get All Service Statuses"
+    )

--- a/MonitoringTools/tests/test_slottifier.py
+++ b/MonitoringTools/tests/test_slottifier.py
@@ -278,6 +278,25 @@ def test_calculate_slots_on_hv_non_gpu_disabled():
     assert res.max_gpu_slots_capacity_enabled == 0
 
 
+def test_calculate_slots_on_hv_gpu_no_gpunum():
+    """
+    tests calculate_slots_on_hv when provided a gpu flavor but gpus_required is set to 0
+    should raise error
+    """
+    with pytest.raises(RuntimeError):
+        calculate_slots_on_hv(
+            # g- specifies gpu flavor
+            "g-flavor1",
+            {"gpus_required": 0, "cores_required": 10, "mem_required": 10},
+            {
+                "compute_service_status": "disabled",
+                # can fit 10 slots, but should be 0 since compute service disabled
+                "cores_available": 100,
+                "mem_available": 100,
+            }
+        )
+
+
 def test_calculate_slots_on_hv_gpu_disabled():
     """
     tests calculate_slots_on_hv calculates slots properly for gpu flavor

--- a/MonitoringTools/tests/test_slottifier.py
+++ b/MonitoringTools/tests/test_slottifier.py
@@ -1,0 +1,542 @@
+from unittest.mock import NonCallableMock, MagicMock, patch, call
+from slottifier import (
+    get_hv_info,
+    get_flavor_requirements,
+    get_valid_flavors_for_aggregate,
+    convert_to_data_string,
+    calculate_slots_on_hv,
+    get_openstack_resources,
+    get_all_hv_info_for_aggregate,
+    update_slots,
+    get_slottifier_details,
+    main,
+)
+import pytest
+
+from slottifier_entry import SlottifierEntry
+
+
+@pytest.fixture(name="mock_hypervisors")
+def mock_hypervisors_fixture():
+    return {
+        "hv1": {
+            "status": "enabled",
+            "vcpus": 8,
+            "vcpus_used": 2,
+            "memory_size": 8192,
+            "memory_used": 2048,
+        },
+        "hv2": {
+            "status": "enabled",
+            "vcpus": 4,
+            "vcpus_used": 6,
+            "memory_size": 2048,
+            "memory_used": 4096,
+        },
+        "hv3": {"status": "disabled"},
+    }
+
+
+@pytest.fixture(name="mock_service_info")
+def mock_service_fixture():
+    return {"status": "enabled"}
+
+
+@pytest.fixture(name="mock_aggregate")
+def mock_aggregate_fixture():
+    def _mock_aggregate(hosttype=None, gpu_num=None):
+        ag = {"metadata": {}}
+        if hosttype:
+            ag["metadata"]["hosttype"] = hosttype
+        if gpu_num:
+            ag["metadata"]["gpunum"] = gpu_num
+        return ag
+
+    return _mock_aggregate
+
+
+@pytest.fixture(name="mock_flavors_list")
+def mock_flavors_fixture():
+    return [
+        {"id": 1, "extra_specs": {"aggregate_instance_extra_specs:hosttype": "A"}},
+        {"id": 2, "extra_specs": {"aggregate_instance_extra_specs:hosttype": "B"}},
+        {"id": 3, "extra_specs": {}},
+        {"id": 4, "extra_specs": {"aggregate_instance_extra_specs:hosttype": "A"}},
+        {"id": 5, "extra_specs": {"aggregate_instance_extra_specs:hosttype": "C"}},
+    ]
+
+
+def test_hypervisor_exists_and_enabled(
+    mock_hypervisors, mock_aggregate, mock_service_info
+):
+    assert get_hv_info(
+        mock_hypervisors["hv1"], mock_aggregate(gpu_num="1"), mock_service_info
+    ) == {
+        "cores_available": 6,
+        "mem_available": 6144,
+        "gpu_capacity": 1,
+        "core_capacity": 8,
+        "mem_capacity": 8192,
+        "compute_service_status": "enabled",
+    }
+
+
+def test_hypervisor_negative_results_floored(
+    mock_hypervisors, mock_aggregate, mock_service_info
+):
+    assert get_hv_info(
+        mock_hypervisors["hv2"], mock_aggregate(), mock_service_info
+    ) == {
+        "cores_available": 0,
+        "mem_available": 0,
+        "gpu_capacity": 0,
+        "core_capacity": 4,
+        "mem_capacity": 2048,
+        "compute_service_status": "enabled",
+    }
+
+
+def test_hypervisor_exists_but_disabled(
+    mock_hypervisors, mock_aggregate, mock_service_info
+):
+    assert get_hv_info(
+        mock_hypervisors["hv3"], mock_aggregate(), mock_service_info
+    ) == {
+        "cores_available": 0,
+        "mem_available": 0,
+        "gpu_capacity": 0,
+        "core_capacity": 0,
+        "mem_capacity": 0,
+        "compute_service_status": "disabled",
+    }
+
+
+def test_get_flavor_requirements_with_all_values():
+    mock_flavor = {
+        "extra_specs": {"accounting:gpu_num": "2"},
+        "vcpus": "4",
+        "ram": "8192",
+    }
+    assert get_flavor_requirements(mock_flavor) == {
+        "gpus_required": 2,
+        "cores_required": 4,
+        "mem_required": 8192,
+    }
+
+
+def test_get_flavor_requirements_with_missing_values():
+    assert get_flavor_requirements({}) == {
+        "gpus_required": 0,
+        "cores_required": 0,
+        "mem_required": 0,
+    }
+
+
+def test_get_flavor_requirements_with_partial_values():
+    req_dict = {"ram": "8192"}
+    assert get_flavor_requirements(req_dict) == {
+        "gpus_required": 0,
+        "cores_required": 0,
+        "mem_required": 8192,
+    }
+
+
+def test_get_valid_flavors_with_matching_type(mock_flavors_list, mock_aggregate):
+    assert get_valid_flavors_for_aggregate(mock_flavors_list, mock_aggregate("A")) == [
+        {"id": 1, "extra_specs": {"aggregate_instance_extra_specs:hosttype": "A"}},
+        {"id": 4, "extra_specs": {"aggregate_instance_extra_specs:hosttype": "A"}},
+    ]
+
+
+def test_get_valid_flavors_with_empty_flavors_list(mock_aggregate):
+    assert get_valid_flavors_for_aggregate([], mock_aggregate("A")) == []
+
+
+def test_get_valid_flavors_with_non_matching_hosttype(
+    mock_flavors_list, mock_aggregate
+):
+    assert get_valid_flavors_for_aggregate(mock_flavors_list, mock_aggregate("D")) == []
+
+
+def test_convert_to_data_string_no_items():
+    """
+    Tests convert_to_data_string returns empty string when given empty dict as slots_dict
+    """
+    assert convert_to_data_string(NonCallableMock(), {}) == ""
+
+
+def test_convert_to_data_string_one_item():
+    """
+    Tests convert_to_data_string works with single entry in dict for slots_dict
+    """
+    mock_instance = "prod"
+
+    mock_slot_info_dataclass = MagicMock()
+    mock_slot_info_dataclass.slots_available = "1"
+    mock_slot_info_dataclass.max_gpu_slots_capacity = "2"
+    mock_slot_info_dataclass.estimated_gpu_slots_used = "3"
+    mock_slot_info_dataclass.max_gpu_slots_capacity_enabled = "4"
+
+    mock_slots_dict = {"flavor1": mock_slot_info_dataclass}
+
+    res = convert_to_data_string(mock_instance, mock_slots_dict)
+    assert res == (
+        "SlotsAvailable,instance=Prod,flavor=flavor1 "
+        "SlotsAvailable=1i,maxSlotsAvailable=2i,usedSlots=3i,enabledSlots=4i\n"
+    )
+
+
+def test_convert_to_data_string_multi_item():
+    """
+    Tests convert_to_data_string works with multiple entries in dict for slots_dict
+    """
+    mock_instance = "prod"
+    mock_slot_info_dataclass = MagicMock()
+    mock_slot_info_dataclass.slots_available = "1"
+    mock_slot_info_dataclass.max_gpu_slots_capacity = "2"
+    mock_slot_info_dataclass.estimated_gpu_slots_used = "3"
+    mock_slot_info_dataclass.max_gpu_slots_capacity_enabled = "4"
+
+    mock_slots_dict = {
+        "flavor1": mock_slot_info_dataclass,
+        "flavor2": mock_slot_info_dataclass,
+    }
+
+    res = convert_to_data_string(mock_instance, mock_slots_dict)
+    assert res == (
+        "SlotsAvailable,instance=Prod,flavor=flavor1 "
+        "SlotsAvailable=1i,maxSlotsAvailable=2i,usedSlots=3i,enabledSlots=4i\n"
+        "SlotsAvailable,instance=Prod,flavor=flavor2 "
+        "SlotsAvailable=1i,maxSlotsAvailable=2i,usedSlots=3i,enabledSlots=4i\n"
+    )
+
+
+def test_calculate_slots_on_hv_non_gpu_disabled():
+    res = calculate_slots_on_hv(
+        "flavor1",
+        {"cores_required": 10, "mem_required": 10},
+        {
+            "compute_service_status": "disabled",
+            # can fit 10 slots, but should be 0 since compute service disabled
+            "cores_available": 100,
+            "mem_available": 100,
+        },
+    )
+    assert res.slots_available == 0
+    assert res.max_gpu_slots_capacity == 0
+    assert res.estimated_gpu_slots_used == 0
+    assert res.max_gpu_slots_capacity_enabled == 0
+
+
+def test_calculate_slots_on_hv_gpu_disabled():
+    res = calculate_slots_on_hv(
+        # g- specifies gpu flavor
+        "g-flavor1",
+        {"gpus_required": 1, "cores_required": 10, "mem_required": 10},
+        {
+            "compute_service_status": "disabled",
+            # can fit 10 slots, but should be 0 since compute service disabled
+            "cores_available": 100,
+            "mem_available": 100,
+            "core_capacity": 100,
+            "mem_capacity": 100,
+            "gpu_capacity": 10,
+        },
+    )
+    assert res.slots_available == 0
+    # still want capacity to be updated
+    assert res.max_gpu_slots_capacity == 10
+    assert res.estimated_gpu_slots_used == 0
+    assert res.max_gpu_slots_capacity_enabled == 0
+
+
+def test_calculate_slots_on_hv_mem_available_max():
+    res = calculate_slots_on_hv(
+        "flavor1",
+        {"cores_required": 10, "mem_required": 10},
+        {
+            "compute_service_status": "enabled",
+            "cores_available": 100,
+            # can fit only one slot
+            "mem_available": 10,
+        },
+    )
+    assert res.slots_available == 1
+    assert res.max_gpu_slots_capacity == 0
+    assert res.estimated_gpu_slots_used == 0
+    assert res.max_gpu_slots_capacity_enabled == 0
+
+
+def test_calculate_slots_on_hv_cores_available_max():
+    res = calculate_slots_on_hv(
+        "flavor1",
+        {"cores_required": 10, "mem_required": 10},
+        {
+            "compute_service_status": "enabled",
+            # can fit 10 cpu slots
+            "cores_available": 100,
+            "mem_available": 1000,
+        },
+    )
+    assert res.slots_available == 10
+    assert res.max_gpu_slots_capacity == 0
+    assert res.estimated_gpu_slots_used == 0
+    assert res.max_gpu_slots_capacity_enabled == 0
+
+
+def test_calculate_slots_on_hv_gpu_available_max():
+    res = calculate_slots_on_hv(
+        # specifies a gpu flavor
+        "g-flavor1",
+        {"gpus_required": 1, "cores_required": 10, "mem_required": 10},
+        {
+            "compute_service_status": "enabled",
+            # should find only 5 slots available since gpus are the limiting factor
+            "gpu_capacity": 5,
+            "cores_available": 100,
+            "mem_available": 100,
+            "core_capacity": 100,
+            "mem_capacity": 100,
+        },
+    )
+    assert res.slots_available == 5
+    assert res.max_gpu_slots_capacity == 5
+    assert res.estimated_gpu_slots_used == 0
+    assert res.max_gpu_slots_capacity_enabled == 5
+
+
+def test_calculate_slots_on_hv_calculates_used_gpu_capacity():
+    res = calculate_slots_on_hv(
+        # specifies a gpu flavor
+        "g-flavor1",
+        {"gpus_required": 1, "cores_required": 10, "mem_required": 10},
+        {
+            "compute_service_status": "enabled",
+            # should find only 5 slots available since gpus are the limiting factor
+            "gpu_capacity": 5,
+            "cores_available": 10,
+            "mem_available": 10,
+            # there's 4 flavor slots that could have already been used
+            "core_capacity": 50,
+            "mem_capacity": 50,
+        },
+    )
+    assert res.slots_available == 1
+    assert res.max_gpu_slots_capacity == 5
+    assert res.estimated_gpu_slots_used == 4
+    assert res.max_gpu_slots_capacity_enabled == 5
+
+
+@patch("slottifier.openstack")
+def test_get_openstack_resources(mock_openstack):
+    mock_conn = mock_openstack.connect.return_value
+
+    mock_conn.list_hypervisors.return_value = [{"name": "hv1", "id": 1}]
+    mock_conn.compute.aggregates.return_value = [{"name": "ag1", "id": 2}]
+    mock_conn.compute.services.return_value = [{"name": "svc1", "id": 3}]
+    mock_conn.compute.flavors.return_value = [{"name": "flv1", "id": 4}]
+
+    mock_instance = NonCallableMock()
+    res = get_openstack_resources(mock_instance)
+
+    mock_openstack.connect.assert_called_once_with(cloud=mock_instance)
+    mock_conn.compute.services.assert_called_once()
+    mock_conn.compute.aggregates.assert_called_once()
+    mock_conn.list_hypervisors.assert_called_once()
+    mock_conn.compute.flavors.assert_called_once_with(get_extra_specs=True)
+
+    assert res == {
+        "compute_services": [{"name": "svc1", "id": 3}],
+        "aggregates": [{"name": "ag1", "id": 2}],
+        "hypervisors": [{"name": "hv1", "id": 1}],
+        "flavors": [{"name": "flv1", "id": 4}],
+    }
+
+
+@pytest.fixture(name="mock_all_compute_services")
+def all_compute_services():
+    return [
+        {"host": "host1", "name": "svc1"},
+        {"host": "host2", "name": "svc2"},
+        {"host": "host3", "name": "svc3"},
+    ]
+
+
+@pytest.fixture(name="mock_all_hypervisors")
+def all_hypervisors():
+    return [
+        {"name": "host1"},
+        {"name": "host2"},
+    ]
+
+
+@patch("slottifier.get_hv_info")
+def test_get_all_hv_info_for_aggregate_with_valid_data(
+    mock_get_hv_info, mock_all_hypervisors, mock_all_compute_services
+):
+    mock_aggregate = {"hosts": ["host1", "host2"]}
+    res = get_all_hv_info_for_aggregate(
+        mock_aggregate, mock_all_compute_services, mock_all_hypervisors
+    )
+    mock_get_hv_info.assert_has_calls(
+        [
+            call({"name": "host1"}, mock_aggregate, {"host": "host1", "name": "svc1"}),
+            call({"name": "host2"}, mock_aggregate, {"host": "host2", "name": "svc2"}),
+        ]
+    )
+    assert res == [mock_get_hv_info.return_value, mock_get_hv_info.return_value]
+
+
+def test_get_all_hv_info_for_aggregate_with_invalid_data(
+    mock_all_hypervisors, mock_all_compute_services
+):
+    mock_aggregate = {
+        "hosts": [
+            # host3 has service but not found in list of hvs
+            "host3",
+            # host4 has no service and not in list of hvs
+            "host4",
+        ]
+    }
+    assert (
+        get_all_hv_info_for_aggregate(
+            mock_aggregate, mock_all_compute_services, mock_all_hypervisors
+        )
+        == []
+    )
+
+
+def test_get_all_hv_info_for_aggregate_with_empty_aggregate(
+    mock_all_hypervisors, mock_all_compute_services
+):
+    mock_aggregate = {"hosts": []}
+    assert (
+        get_all_hv_info_for_aggregate(
+            mock_aggregate, mock_all_compute_services, mock_all_hypervisors
+        )
+        == []
+    )
+
+
+@patch("slottifier.get_flavor_requirements")
+@patch("slottifier.calculate_slots_on_hv")
+def test_update_slots_one_flavor_one_hv(
+    mock_calculate_slots_on_hv, mock_get_flavor_requirements
+):
+    mock_flavor = {"name": "flv1"}
+    mock_host = NonCallableMock()
+
+    slots_dict = {"flv1": 1}
+    mock_calculate_slots_on_hv.return_value = 1
+    res = update_slots([mock_flavor], [mock_host], slots_dict=slots_dict)
+    mock_get_flavor_requirements.assert_called_once_with(mock_flavor)
+    mock_calculate_slots_on_hv.assert_called_once_with(
+        "flv1", mock_get_flavor_requirements.return_value, mock_host
+    )
+    assert res == {"flv1": 2}
+
+
+@patch("slottifier.get_flavor_requirements")
+@patch("slottifier.calculate_slots_on_hv")
+def test_update_slots_one_flavor_multi_hv(
+    mock_calculate_slots_on_hv, mock_get_flavor_requirements
+):
+    mock_flavor = {"name": "flv1"}
+    mock_host_1 = NonCallableMock()
+    mock_host_2 = NonCallableMock()
+    slots_dict = {"flv1": 1}
+    mock_calculate_slots_on_hv.side_effect = [1, 2]
+    res = update_slots([mock_flavor], [mock_host_1, mock_host_2], slots_dict=slots_dict)
+    mock_get_flavor_requirements.assert_called_once_with(mock_flavor)
+    mock_calculate_slots_on_hv.assert_has_calls(
+        [
+            call("flv1", mock_get_flavor_requirements.return_value, mock_host_1),
+            call("flv1", mock_get_flavor_requirements.return_value, mock_host_2),
+        ]
+    )
+    assert res == {"flv1": 4}
+
+
+@patch("slottifier.get_flavor_requirements")
+@patch("slottifier.calculate_slots_on_hv")
+def test_update_slots_multi_flavor_multi_hv(
+    mock_calculate_slots_on_hv, mock_get_flavor_requirements
+):
+    mock_flavor_1 = {"name": "flv1"}
+    mock_flavor_2 = {"name": "flv2"}
+    mock_host_1 = NonCallableMock()
+    mock_host_2 = NonCallableMock()
+    slots_dict = {"flv1": 1, "flv2": 0}
+    mock_calculate_slots_on_hv.side_effect = [1, 2, 0, 0]
+    res = update_slots(
+        [mock_flavor_1, mock_flavor_2],
+        [mock_host_1, mock_host_2],
+        slots_dict=slots_dict,
+    )
+    mock_get_flavor_requirements.assert_has_calls(
+        [call(mock_flavor_1), call(mock_flavor_2)]
+    )
+    mock_calculate_slots_on_hv.assert_has_calls(
+        [
+            call("flv1", mock_get_flavor_requirements.return_value, mock_host_1),
+            call("flv1", mock_get_flavor_requirements.return_value, mock_host_2),
+            call("flv2", mock_get_flavor_requirements.return_value, mock_host_1),
+            call("flv2", mock_get_flavor_requirements.return_value, mock_host_2),
+        ]
+    )
+    assert res == {"flv1": 4, "flv2": 0}
+
+
+@patch("slottifier.get_openstack_resources")
+@patch("slottifier.get_valid_flavors_for_aggregate")
+@patch("slottifier.get_all_hv_info_for_aggregate")
+@patch("slottifier.update_slots")
+@patch("slottifier.convert_to_data_string")
+def test_get_slottifier_details_one_aggregate(
+    mock_convert_to_data_string,
+    mock_update_slots,
+    mock_get_all_hv_info_for_aggregate,
+    mock_get_valid_flavors_for_aggregate,
+    mock_get_openstack_resources,
+):
+    mock_instance = NonCallableMock()
+    mock_flavors = [{"name": "flv1"}, {"name": "flv2"}]
+    mock_compute_services = NonCallableMock()
+    mock_hypervisors = NonCallableMock()
+
+    mock_get_openstack_resources.return_value = {
+        "aggregates": ["ag1"],
+        "flavors": mock_flavors,
+        "compute_services": mock_compute_services,
+        "hypervisors": mock_hypervisors,
+    }
+    res = get_slottifier_details(mock_instance)
+    mock_get_openstack_resources.assert_called_once_with(mock_instance)
+    mock_get_valid_flavors_for_aggregate.assert_called_once_with(mock_flavors, "ag1")
+    mock_get_all_hv_info_for_aggregate.assert_called_once_with(
+        "ag1", mock_compute_services, mock_hypervisors
+    )
+
+    mock_update_slots.assert_called_once_with(
+        mock_get_valid_flavors_for_aggregate.return_value,
+        mock_get_all_hv_info_for_aggregate.return_value,
+        {"flv1": SlottifierEntry(), "flv2": SlottifierEntry()},
+    )
+
+    mock_convert_to_data_string.assert_called_once_with(
+        mock_instance, mock_update_slots.return_value
+    )
+    assert res == mock_convert_to_data_string.return_value
+
+
+@patch("slottifier.run_scrape")
+@patch("slottifier.parse_args")
+def test_main(mock_parse_args, mock_run_scrape):
+    mock_user_args = NonCallableMock()
+    main(mock_user_args)
+    mock_run_scrape.assert_called_once_with(
+        mock_parse_args.return_value, get_slottifier_details
+    )
+    mock_parse_args.assert_called_once_with(
+        mock_user_args, description="Get All Service Statuses"
+    )

--- a/MonitoringTools/tests/test_slottifier_entry.py
+++ b/MonitoringTools/tests/test_slottifier_entry.py
@@ -1,0 +1,24 @@
+from slottifier_entry import SlottifierEntry
+
+
+def test_add():
+    a = SlottifierEntry(
+        slots_available=1,
+        estimated_gpu_slots_used=1,
+        max_gpu_slots_capacity=1,
+        max_gpu_slots_capacity_enabled=1
+    )
+
+    b = SlottifierEntry(
+        slots_available=2,
+        estimated_gpu_slots_used=3,
+        max_gpu_slots_capacity=4,
+        max_gpu_slots_capacity_enabled=5
+    )
+
+    assert a + b == SlottifierEntry(
+        slots_available=3,
+        estimated_gpu_slots_used=4,
+        max_gpu_slots_capacity=5,
+        max_gpu_slots_capacity_enabled=6
+    )

--- a/MonitoringTools/tests/test_slottifier_entry.py
+++ b/MonitoringTools/tests/test_slottifier_entry.py
@@ -2,6 +2,9 @@ from slottifier_entry import SlottifierEntry
 
 
 def test_add():
+    """
+    test that adding two SlottifierEntry dataclasses works properly
+    """
     a = SlottifierEntry(
         slots_available=1,
         estimated_gpu_slots_used=1,

--- a/MonitoringTools/usr/local/bin/influxdb.conf
+++ b/MonitoringTools/usr/local/bin/influxdb.conf
@@ -4,7 +4,7 @@ password=admin
 username=admin
 
 [cloud]
-# requires ~/.config/openstack/clouds.yaml with "prod" cloud account
+# requires /etc/openstack/clouds.yaml with "prod" cloud account
 instance=prod
 
 [db]

--- a/MonitoringTools/usr/local/bin/influxdb.conf
+++ b/MonitoringTools/usr/local/bin/influxdb.conf
@@ -1,0 +1,12 @@
+[auth]
+# auth for influxdb
+password=admin
+username=admin
+
+[cloud]
+# requires ~/.config/openstack/clouds.yaml with "prod" cloud account
+instance=prod
+
+[db]
+database=cloud
+host=localhost:8086

--- a/MonitoringTools/usr/local/bin/limits_to_influx.py
+++ b/MonitoringTools/usr/local/bin/limits_to_influx.py
@@ -20,8 +20,8 @@ def convert_to_data_string(instance: str, limit_details: Dict) -> str:
         parsed_project_name = project_name.replace(" ", "\ ")
         data_string += (
             f'Limits,Project="{parsed_project_name}",'
-            f'instance={instance.capitalize()} '
-            f'{get_limit_prop_string(limit_entry)}'
+            f"instance={instance.capitalize()} "
+            f"{get_limit_prop_string(limit_entry)}"
         )
     return data_string
 
@@ -46,7 +46,9 @@ def get_limits_for_project(instance, project_id) -> Dict:
     :return: a set of limit properties for project we want
     """
     command = f"openstack --os-cloud={instance} limits show -f json --noindent --absolute --project {project_id}"
-    project_limits = json.loads(Popen(command, shell=True, stdout=PIPE).communicate()[0])
+    project_limits = json.loads(
+        Popen(command, shell=True, stdout=PIPE).communicate()[0]
+    )
     # all limit properties are integers so add 'i' for each value
     return {limit_entry["Name"]: limit_entry["Value"] for limit_entry in project_limits}
 
@@ -85,5 +87,5 @@ def main(user_args: List):
     run_scrape(influxdb_args, get_all_limits)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main(sys.argv[1:])

--- a/MonitoringTools/usr/local/bin/limits_to_influx.py
+++ b/MonitoringTools/usr/local/bin/limits_to_influx.py
@@ -21,7 +21,7 @@ def convert_to_data_string(instance: str, limit_details: Dict) -> str:
         data_string += (
             f'Limits,Project="{parsed_project_name}",'
             f"instance={instance.capitalize()} "
-            f"{get_limit_prop_string(limit_entry)}"
+            f"{get_limit_prop_string(limit_entry)}\n"
         )
     return data_string
 

--- a/MonitoringTools/usr/local/bin/limits_to_influx.py
+++ b/MonitoringTools/usr/local/bin/limits_to_influx.py
@@ -32,7 +32,10 @@ def get_limit_prop_string(limit_details):
     :return: a data string of scraped info
     """
     # all limit properties are integers so add 'i' for each value
-    return ",".join([f"{limit}={val}i" for limit, val in limit_details.items()])
+    limit_strings = []
+    for limit, val in limit_details.items():
+        limit_strings.append(f"{limit}={val}i")
+    return ",".join(limit_strings)
 
 
 def extract_limits(limits_dict) -> Dict:
@@ -72,7 +75,7 @@ def extract_limits(limits_dict) -> Dict:
     return parsed_limits
 
 
-def get_limits_for_project(instance, project_id) -> Dict:
+def get_limits_for_project(instance: str, project_id) -> Dict:
     """
     Get limits for a project. This is currently using openstack-cli
     This will be rewritten to instead use openstacksdk
@@ -95,7 +98,7 @@ def is_valid_project(project: Project) -> bool:
     :return: boolean, True if project should be accounted for in limits
     """
     invalid_strings = ["_rally", "844"]
-    return all(s not in project["name"] for s in invalid_strings)
+    return all(string not in project["name"] for string in invalid_strings)
 
 
 def get_all_limits(instance: str) -> str:
@@ -105,11 +108,10 @@ def get_all_limits(instance: str) -> str:
     :return: A data string of scraped info
     """
     conn = openstack.connect(cloud=instance)
-    limit_details = {
-        project["name"]: get_limits_for_project(instance, project["id"])
-        for project in conn.list_projects()
-        if is_valid_project(project)
-    }
+    limit_details = {}
+    for project in conn.list_projects():
+        if is_valid_project(project):
+            limit_details[project["name"]] = get_limits_for_project(instance, project["id"])
     return convert_to_data_string(instance, limit_details)
 
 

--- a/MonitoringTools/usr/local/bin/limits_to_influx.py
+++ b/MonitoringTools/usr/local/bin/limits_to_influx.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python
+import sys
+from typing import Dict
+import time
+import openstack
+from send_metric_utils import parse_args, post_to_influxdb, underscore_to_camelcase
+
+
+def parse_compute_limits(compute_limit_dict: Dict) -> Dict:
+    """
+    parse compute limits dict to extract properties we want in correct format
+    :param compute_limit_dict: a dictionary holding compute limits
+    :return: Dict of useful properties
+    """
+    compute_limits = {
+        # need to convert to limit name camelCase as that's what influx is expecting
+        underscore_to_camelcase(k): v for k, v in compute_limit_dict.items()
+        # add limit 'properties' later - as this is nested and already in camelCase
+        if k not in ["location", "properties"]
+    }
+    compute_limits.update(compute_limit_dict["properties"])
+    return compute_limits
+
+
+def convert_to_data_string(limit_details: Dict, instance: str) -> str:
+    """
+    converts a dictionary of values into a data-string influxdb can read
+    :param limit_details: a dictionary of values to convert to string
+    :param instance: which cloud the info was scraped from (prod or dev)
+    :return: a comma-separated string of key=value taken from input dictionary
+    """
+    data_string = ""
+    for project_name, limit_details in limit_details.items():
+        parsed_project_name = project_name.replace(" ", "\ ")
+        data_string += (
+            f'Limits,Project="{parsed_project_name}",'
+            f'instance={instance.capitalize()} '
+            f'{get_limit_prop_string(limit_details)}'
+        )
+    return data_string
+
+
+def get_limit_prop_string(limit_details):
+    """
+    This function is a helper function that creates a partial data string of just the
+    properties scraped for a single service
+    :param limit_details: properties scraped for a single project
+    :return: a data string of scraped info
+    """
+    # all limit properties are integers so add 'i' for each value
+    return ",".join([f"{limit}={val}i" for limit, val in limit_details.items()])
+
+
+def get_all_limits(instance: str) -> str:
+    """
+    This function gets limits for each project on openstack
+    :param instance: which cloud to scrape from (prod or dev)
+    :return: A data string of scraped info
+    """
+    conn = openstack.connect(cloud=instance)
+
+    projects_list = [
+        proj for proj in conn.list_projects()
+        if all(s not in proj["name"] for s in ("_rally", "844"))
+    ]
+
+    limit_details = {}
+    print(len(projects_list))
+    for i, project in enumerate(projects_list, 1):
+
+        project_details = {
+            **parse_compute_limits(conn.get_compute_limits(project["id"])),
+            **conn.get_volume_limits(project["id"])["absolute"]
+        }
+        print(i)
+        limit_details[project["name"]] = project_details
+    return convert_to_data_string(limit_details, instance)
+
+
+def main(influxdb_args: Dict):
+    """
+    send limits to influx
+    :param influxdb_args: args to connect to influxdb and openstack to scrape info from
+    """
+    post_to_influxdb(
+        get_all_limits(influxdb_args["cloud.instance"]),
+        host=influxdb_args["db.host"],
+        db_name=influxdb_args["db.database"],
+        auth=(influxdb_args["auth.username"], influxdb_args["auth.password"])
+    )
+
+
+if __name__ == '__main__':
+    main(parse_args(sys.argv[1:], description="Get All Project Limits"))

--- a/MonitoringTools/usr/local/bin/send_metric_utils.py
+++ b/MonitoringTools/usr/local/bin/send_metric_utils.py
@@ -26,7 +26,9 @@ def read_config_file(config_filepath: Path) -> Dict:
         "db.database",
         "db.host",
     ]
-    assert all(val in config_dict for val in required_values), "Config file is missing required values."
+    assert all(
+        val in config_dict for val in required_values
+    ), "Config file is missing required values."
     return config_dict
 
 
@@ -88,5 +90,5 @@ def run_scrape(influxdb_args, scrape_func: Callable[[str], str]):
         scrape_res,
         host=influxdb_args["db.host"],
         db_name=influxdb_args["db.database"],
-        auth=(influxdb_args["auth.username"], influxdb_args["auth.password"])
+        auth=(influxdb_args["auth.username"], influxdb_args["auth.password"]),
     )

--- a/MonitoringTools/usr/local/bin/send_metric_utils.py
+++ b/MonitoringTools/usr/local/bin/send_metric_utils.py
@@ -49,19 +49,6 @@ def post_to_influxdb(
         print(r.text)
 
 
-def underscore_to_camelcase(input_string: str) -> str:
-    """
-    This function converts an underscore_delimited_string to camelCase
-    :param input_string: underscore_delimited_string
-    :return: camelCase string
-    """
-    words = input_string.split("_")
-    camelcase_string = "".join(
-        [word.capitalize() if i > 0 else word for i, word in enumerate(words)]
-    )
-    return camelcase_string
-
-
 def parse_args(inp_args, description: str = "scrape metrics script") -> Dict:
     """
     This function parses influxdb args from a filepath passed into script when its run.

--- a/MonitoringTools/usr/local/bin/send_metric_utils.py
+++ b/MonitoringTools/usr/local/bin/send_metric_utils.py
@@ -1,0 +1,90 @@
+from typing import Dict, Tuple
+from pathlib import Path
+import configparser
+import requests
+import argparse
+from configparser import ConfigParser
+
+
+def read_config_file(config_filepath: Path) -> Dict:
+    """
+    This function reads a config file and puts it into a dictionary
+    :param config_filepath:
+    :return: A flattened dictionary containing key-value pairs from config file
+    """
+    config = ConfigParser()
+    config.read(config_filepath)
+    config_dict = {}
+    for section in config.sections():
+        for key, value in config.items(section):
+            config_dict[f"{section}.{key}"] = value
+
+    for i in [
+        "auth.password",
+        "auth.username",
+        "cloud.instance",
+        "db.database",
+        "db.host",
+    ]:
+        assert i in config_dict, f"config file is missing required value {i}"
+
+    return config_dict
+
+
+def post_to_influxdb(
+    data_string: str, host: str, db_name: str, auth: Tuple[str, str]
+) -> None:
+    """
+    This function posts information to influxdb
+    :param data_string: data to write
+    :param host: hostname and port where influxdb can be accessed
+    :param db_name: database name to write to
+    :param auth: tuple of username and password to authenticate with influxdb
+    """
+    print("POSTING TO INFLUX")
+    if data_string:
+        url = "http://{0}/write?db={1}&precision=s".format(host, db_name)
+        r = requests.post(url, data=data_string, auth=auth)
+        print(r)
+        print(r.text)
+
+
+def underscore_to_camelcase(input_string: str) -> str:
+    """
+    This function converts an underscore_delimited_string to camelCase
+    :param input_string: underscore_delimited_string
+    :return: camelCase string
+    """
+    words = input_string.split("_")
+    camelcase_string = "".join(
+        [word.capitalize() if i > 0 else word for i, word in enumerate(words)]
+    )
+    return camelcase_string
+
+
+def parse_args(inp_args, description: str = "scrape metrics script") -> Dict:
+    """
+    This function parses influxdb args from a filepath passed into script when its run.
+    The only thing the scripts takes as input is the path to the config file.
+    :param description: The description of the script to print on help command
+    :param inp_args: input arguments passed when a 'gather metrics' script is run
+    :return: args from
+    """
+
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "config_filepath", type=Path, help="Path to influxdb config file"
+    )
+    args = parser.parse_args(inp_args)
+
+    # Check if the specified config file exists
+    if not args.config_filepath.exists():
+        parser.error(
+            f"The influxdb config file '{args.config_filepath}' does not exist."
+        )
+    try:
+        return read_config_file(args.config_filepath)
+    except configparser.Error as exp:
+        raise RuntimeError(
+            f"could not read influxdb config file '{args.config_filepath}'"
+        ) from exp

--- a/MonitoringTools/usr/local/bin/service_status_to_influx.py
+++ b/MonitoringTools/usr/local/bin/service_status_to_influx.py
@@ -84,7 +84,7 @@ def convert_to_data_string(instance: str, service_details: Dict) -> str:
             data_string += (
                 f'ServiceStatus,host="{hypervisor_name}",'
                 f'service="{service_binary}",instance={instance.capitalize()} '
-                f'{get_service_prop_string(service_stats)}'
+                f"{get_service_prop_string(service_stats)}"
             )
     return data_string
 
@@ -153,9 +153,7 @@ def update_with_agent_statuses(conn, status_details: Dict) -> Dict:
         if agent["host"] not in status_details.keys():
             status_details[agent["host"]] = {}
 
-        status_details[agent["host"]].update(
-            get_agent_properties(agent)
-        )
+        status_details[agent["host"]].update(get_agent_properties(agent))
 
     return status_details
 
@@ -183,5 +181,5 @@ def main(user_args: List):
     run_scrape(influxdb_args, get_all_service_statuses)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main(sys.argv[1:])

--- a/MonitoringTools/usr/local/bin/service_status_to_influx.py
+++ b/MonitoringTools/usr/local/bin/service_status_to_influx.py
@@ -1,0 +1,164 @@
+#!/usr/bin/python
+import sys
+from typing import Dict
+import openstack
+from openstack.compute.v2.hypervisor import Hypervisor
+from openstack.compute.v2.service import Service
+from openstack.network.v2.agent import Agent
+
+
+from send_metric_utils import (
+    parse_args,
+    post_to_influxdb,
+)
+
+
+def get_hypervisor_properties(hypervisor: Hypervisor) -> Dict:
+    """
+    This function parses a openstacksdk Hypervisor object to get properties in the correct format
+    to feed into influxdb
+    :param hypervisor: hypervisor to extract properties from
+    :return: A dictionary of useful properties
+    """
+    hv_prop_dict = {
+        "hv": {
+            # this is populated by another command
+            "aggregate": "no-aggregate",
+            "memorymax": hypervisor["memory_size"],
+            "memoryused": hypervisor["memory_used"],
+            "memoryavailable": hypervisor["memory_free"],
+            "cpumax": hypervisor["vcpus"],
+            "cpuused": hypervisor["vcpus_used"],
+            "cpuavailable": hypervisor["vcpus"] - hypervisor["vcpus_used"],
+            "agent": 1,
+            "state": 1 if hypervisor["state"] == "up" else 0,
+            "statetext": hypervisor["state"].capitalize(),
+        }
+    }
+    return hv_prop_dict
+
+
+def get_service_properties(service: Service) -> Dict:
+    """
+    This function parses a openstacksdk Service object to get properties in the correct format
+    to feed into influxdb
+    :param service: service to extract properties from
+    :return: A dictionary of useful properties
+    """
+    service_prop_dict = {
+        service["binary"]: {
+            "agent": 1,
+            "status": 1 if service["status"] == "enabled" else 0,
+            "statustext": service["status"].capitalize(),
+            "state": 1 if service["state"] == "up" else 0,
+            "statetext": service["state"].capitalize(),
+        }
+    }
+    return service_prop_dict
+
+
+def get_agent_properties(agent: Agent) -> Dict:
+    """
+    This function parses a openstacksdk Agent object to get properties in the correct format
+    to feed into influxdb
+    :param agent: agent to extract properties from
+    :return: A dictionary of useful properties
+    """
+    agent_prop_dict = {
+        agent["binary"]: {
+            "agent": 1,
+            "state": 1 if agent["is_alive"] else 0,
+            "statetext": "Up" if agent["is_alive"] else "Down",
+            "status": 1 if agent["is_admin_state_up"] else 0,
+            "statustext": "Enabled" if agent["is_admin_state_up"] else "Disabled",
+        }
+    }
+    return agent_prop_dict
+
+
+def convert_to_data_string(service_details: Dict, instance: str) -> str:
+    """
+    This function creates a data string from service properties to feed into influxdb
+    :param service_details: a set of service properties to parse
+    :param instance: the cloud instance (prod or dev) that details were scraped from
+    :return: A data string of scraped info
+    """
+    data_string = ""
+    for hypervisor_name, services in service_details.items():
+        for service_binary, service_stats in services.items():
+            data_string += (
+                f'ServiceStatus,host="{hypervisor_name}",'
+                f'service="{service_binary}",instance={instance.capitalize()} '
+                f'{get_service_prop_string(service_stats)}'
+            )
+    return data_string
+
+
+def get_service_prop_string(service_dict: Dict) -> str:
+    """
+    This function is a helper function that creates a partial data string of just the
+    properties scraped for a single service
+    :param service_dict: properties scraped for a single service
+    :return: a data string of scraped info
+    """
+    stats_strings = []
+    for stat, val in service_dict.items():
+        parsed_val = val
+        if stat not in ["statetext", "statustext", "aggregate"]:
+            parsed_val = f"{val}i"
+        stats_strings.append(f'{stat}="{parsed_val}"')
+    return ",".join(stats_strings)
+
+
+def get_all_service_statuses(instance: str) -> str:
+    """
+    This function gets status information for each service node, hypervisor and network
+    agent in openstack.
+    :param instance: which cloud to scrape from (prod or dev)
+    :return: A data string of scraped info
+    """
+    all_details = {}
+    conn = openstack.connect(cloud=instance)
+    for hypervisor in conn.list_hypervisors():
+        all_details[hypervisor["name"]] = get_hypervisor_properties(hypervisor)
+
+    # populate found hypervisors with what aggregate they belong to - so we can filter by aggregate in grafana
+    for aggregate in conn.compute.aggregates():
+        for host_name in aggregate["hosts"]:
+            if host_name in all_details.keys():
+                all_details[host_name]["hv"]["aggregate"] = aggregate["name"]
+
+    for service in conn.compute.services():
+        if service["host"] not in all_details.keys():
+            all_details[service["host"]] = {}
+        all_details[service["host"]] = get_service_properties(service)
+        if (
+            service["binary"] == "nova-compute"
+            and "hv" in all_details[service["host"]].keys()
+        ):
+            all_details[service["host"]]["hv"]["status"] = all_details[service["host"]][
+                service["binary"]
+            ]["status"]
+
+    for agent in conn.network.agents():
+        if agent["host"] not in all_details.keys():
+            all_details[agent["host"]] = {}
+        all_details[agent["host"]] = get_agent_properties(agent)
+    return convert_to_data_string(all_details, instance)
+
+
+def main(influxdb_args: Dict):
+    """
+    send service status to influx
+    :param influxdb_args: args to connect to influxdb and openstack to scrape info from
+    """
+    post_to_influxdb(
+        get_all_service_statuses(influxdb_args["cloud.instance"]),
+        host=influxdb_args["db.host"],
+        db_name=influxdb_args["db.database"],
+        auth=(influxdb_args["auth.username"], influxdb_args["auth.password"])
+    )
+
+
+if __name__ == "__main__":
+    main(parse_args(sys.argv[1:], description="Get All Service Statuses"))

--- a/MonitoringTools/usr/local/bin/service_status_to_influx.py
+++ b/MonitoringTools/usr/local/bin/service_status_to_influx.py
@@ -84,7 +84,7 @@ def convert_to_data_string(instance: str, service_details: Dict) -> str:
             data_string += (
                 f'ServiceStatus,host="{hypervisor_name}",'
                 f'service="{service_binary}",instance={instance.capitalize()} '
-                f"{get_service_prop_string(service_stats)}"
+                f"{get_service_prop_string(service_stats)}\n"
             )
     return data_string
 

--- a/MonitoringTools/usr/local/bin/slottifier.py
+++ b/MonitoringTools/usr/local/bin/slottifier.py
@@ -47,13 +47,23 @@ def get_flavor_requirements(flavor) -> Dict:
     :param flavor: flavor to get requirements from
     :return: dictionary of requirements
     """
-    return {
+    try:
+        flavor_reqs = {
+            "cores_required": int(flavor["vcpus"]),
+            "mem_required": int(flavor["ram"]),
+        }
+    except (ValueError, KeyError) as exp:
+        flavor_name = flavor.get("name", "Name Not Found")
+        raise RuntimeError(
+            f"could not get flavor requirements for flavor {flavor_name}"
+        ) from exp
+
+    flavor_reqs.update({
         "gpus_required": int(
             flavor.get("extra_specs", {}).get("accounting:gpu_num", 0)
         ),
-        "cores_required": int(flavor.get("vcpus", 0)),
-        "mem_required": int(flavor.get("ram", 0)),
-    }
+    })
+    return flavor_reqs
 
 
 def get_valid_flavors_for_aggregate(flavor_list: List, aggregate: Dict) -> List:

--- a/MonitoringTools/usr/local/bin/slottifier.py
+++ b/MonitoringTools/usr/local/bin/slottifier.py
@@ -1,0 +1,190 @@
+#!/usr/bin/python
+from typing import List, Dict
+import sys
+import re
+from typing import Dict
+import time
+import openstack
+from slottifier_entry import SlottifierEntry
+from send_metric_utils import (
+    parse_args,
+    post_to_influxdb,
+)
+
+UNKNOWN_GPU_NUM_FLAVORS = []
+
+
+def get_hv_info(hv_name: str, hypervisors: Dict) -> Dict:
+    """
+    Helper function to get hv information on cores/memory available
+    :param hv_name: hypervisor name to get information from
+    :param hypervisors: a list of all hypervisors to search in (avoids long search times by getting each one from openstack)
+    :return: a dictionary of cores/memory available for given hv
+    """
+    hv_info = {"cores_available": 0, "mem_available": 0}
+    hypervisor = hypervisors.get(hv_name, {})
+    if hypervisor and hypervisor["status"] != "disabled":
+        hv_info["cores_available"] = max(0, hypervisor.get("vcpus", 0) - hypervisor.get("vcpus_used", 0))
+        hv_info["mem_available"] = max(0, hypervisor.get("memory_size", 0) - hypervisor.get("memory_used", 0))
+
+    return hv_info
+
+
+def get_flavor_requirements(flavor) -> Dict:
+    """
+    Helper function to get flavor memory/ram/gpu requirements for a VM of that type to be built on a hv
+    :param flavor: flavor to get requirements from
+    :return: dictionary of requirements
+    """
+    return {
+        "gpus_required": int(flavor["extra_specs"].get("accounting:gpu_num", 0)),
+        "cores_required": int(flavor.get("vcpus", 0)),
+        "mem_required": int(flavor.get("ram", 0))
+    }
+
+
+def get_valid_flavors_for_hosttype(flavor_list: List, hypervisor_hosttype: str) -> List:
+    """
+    Helper function that filters a list of flavors to find those that can be built on a hypervisor with a given hosttype
+    :param flavor_list: a list of flavors to check
+    :param hypervisor_hosttype: specifies the hypervisor hosttype to find compatible flavors for
+    :return: a list of valid flavors for hosttype
+    """
+    valid_flavors = []
+    for flavor in flavor_list:
+        # validate that flavor can be used on host aggregate
+        if "aggregate_instance_extra_specs:hosttype" not in flavor["extra_specs"].keys():
+            continue
+        if flavor["extra_specs"]["aggregate_instance_extra_specs:hosttype"] != hypervisor_hosttype:
+            continue
+
+        valid_flavors.append(flavor)
+
+    return valid_flavors
+
+
+def convert_to_data_string(slots_dict: Dict, instance: str) -> str:
+    """
+    converts a dictionary of values into a data-string influxdb can read
+    :param slots_dict: a dictionary of slots available for each flavor
+    :param instance: which cloud the info was scraped from (prod or dev)
+    :return: a comma-separated string of key=value taken from input dictionary
+    """
+    data_string = ""
+    for flavor, slot_info in slots_dict.items():
+        data_string += (
+            f"SlotsAvailable,instance={instance},flavor={flavor}"
+            f" SlotsAvailable={slot_info.slots_available}"
+            f",maxSlotsAvailable={slot_info.max_gpu_slots_capacity}"
+            f",usedSlots={slot_info.estimated_gpu_slots_used}"
+            f",enabledSlots={slot_info.max_gpu_slots_capacity_enabled}\n"
+        )
+    return data_string
+
+
+def calculate_slots_for_flavor_for_hv(flavor_name, flavor_reqs, hv_info) -> SlottifierEntry:
+    """
+    Helper function that calculates available slots for a flavor on a given hypervisor
+    :param flavor_name: name of flavor
+    :param flavor_reqs: dictionary of memory, cpu, and gpu requirements of flavor
+    :param hv_info: dictionary of memory, cpu, and gpu capacity/availability on hypervisor
+        and whether hv compute service is enabled
+    :return: A dataclass holding slottifer information to update with
+    """
+    slots_available = 0
+    slots_dataclass = SlottifierEntry()
+
+    if hv_info["compute_service_status"] == "enabled":
+        slots_available = min(
+            hv_info["cores_available"] // flavor_reqs["cores_required"],
+            hv_info["mem_available"] // flavor_reqs["mem_required"]
+        )
+
+    if "g-" in flavor_name:
+
+        # workaround for bugs where gpu number not specified
+        if flavor_reqs["gpus_required"] == 0:
+            flavor_reqs["gpus_required"] = 1
+            if flavor_name not in UNKNOWN_GPU_NUM_FLAVORS:
+                UNKNOWN_GPU_NUM_FLAVORS.append(flavor_name)
+
+        # if the number of GPUs currently assigned on this host is 0, this is how many slots are available
+        theoretical_gpu_slots_available = hv_info["gpu_capacity"] // flavor_reqs["gpus_required"]
+
+        # estimated number of GPU slots used - based off of how much cpu/mem is currently being used
+        slots_dataclass.estimated_gpu_slots_used = hv_info["gpu_capacity"] - slots_available
+
+        slots_dataclass.max_gpu_slots_capacity += hv_info["gpu_capacity"]
+
+        if hv_info["compute_service_status"] == "enabled":
+            slots_dataclass.max_gpu_slots_capacity_enabled = hv_info["gpu_capacity"]
+
+        slots_available = min(slots_available, theoretical_gpu_slots_available)
+
+    slots_dataclass.slots_available = slots_available
+    return slots_dataclass
+
+
+def get_slottifier_details(instance: str) -> str:
+    """
+    This function gets calculates slots available for each flavor in openstack and outputs results in
+    data string format which can be posted to InfluxDB
+    :param instance: which cloud to calculate slots for
+    :return: A data string of scraped info
+    """
+    conn = openstack.connect(cloud=instance)
+
+    # we get all openstack info first because it is quicker than getting them one at a time
+    # dictionaries prevent duplicates
+    all_compute_services = {service["id"]: service for service in conn.compute.services()}
+    print("got all compute services")
+    all_aggregates = {aggregate["id"]: aggregate for aggregate in conn.compute.aggregates()}
+    print("got all aggregates")
+    all_hypervisors = {h["name"]: h for h in conn.list_hypervisors()}
+    print("got all hypervisors")
+    all_flavors = {flavor["name"]: flavor for flavor in conn.compute.flavors(get_extra_specs=True)}
+    print("got all flavors")
+
+    slots_dict = {flavor_name: SlottifierEntry() for flavor_name in all_flavors}
+    for aggregate in all_aggregates.values():
+
+        hv_hosttype = aggregate["metadata"].get("hosttype", None)
+        if not hv_hosttype:
+            continue
+
+        for compute_service in all_compute_services.values():
+            hv_info = get_hv_info(compute_service["host"], all_hypervisors)
+            hv_info["gpu_capacity"] = int(aggregate["metadata"].get("gpunum", 0))
+            hv_info["compute_service_status"] = compute_service["status"]
+
+            valid_flavors = get_valid_flavors_for_hosttype(list(all_flavors.values()), hv_hosttype)
+            for flavor in valid_flavors:
+                slots_dict[flavor["name"]] += calculate_slots_for_flavor_for_hv(
+                    flavor["name"],
+                    get_flavor_requirements(flavor),
+                    hv_info,
+                )
+
+    return convert_to_data_string(slots_dict, instance)
+
+
+def main(influxdb_args: Dict):
+    """
+    send slottifier info to influx
+    :param influxdb_args: args to connect to influxdb and openstack to scrape info from
+    """
+    post_to_influxdb(
+        get_slottifier_details(influxdb_args["cloud.instance"]),
+        host=influxdb_args["db.host"],
+        db_name=influxdb_args["db.database"],
+        auth=(influxdb_args["auth.username"], influxdb_args["auth.password"])
+    )
+    for missing_flavor in UNKNOWN_GPU_NUM_FLAVORS:
+        print(
+            f"{missing_flavor} missing metadata property 'extra_specs:accounting:gpu_num'"
+            "do not know how many GPUs the flavor requires, assuming 1 gpu required"
+        )
+
+
+if __name__ == '__main__':
+    main(parse_args(sys.argv[1:], description="Get Slots Available For All Flavors"))

--- a/MonitoringTools/usr/local/bin/slottifier.py
+++ b/MonitoringTools/usr/local/bin/slottifier.py
@@ -7,7 +7,7 @@ from slottifier_entry import SlottifierEntry
 from send_metric_utils import parse_args, run_scrape
 
 
-def get_hv_info(hypervisor: Dict, aggregate_info, service_info) -> Dict:
+def get_hv_info(hypervisor: Dict, aggregate_info: Dict, service_info: Dict) -> Dict:
     """
     Helper function to get hv information on cores/memory available
     :param hypervisor: a dictionary holding info on hypervisor
@@ -39,7 +39,7 @@ def get_hv_info(hypervisor: Dict, aggregate_info, service_info) -> Dict:
     return hv_info
 
 
-def get_flavor_requirements(flavor) -> Dict:
+def get_flavor_requirements(flavor: Dict) -> Dict:
     """
     Helper function to get flavor memory/ram/gpu requirements for a VM of that type to be built on a hv
     :param flavor: flavor to get requirements from
@@ -112,7 +112,7 @@ def convert_to_data_string(instance: str, slots_dict: Dict) -> str:
     return data_string
 
 
-def calculate_slots_on_hv(flavor_name, flavor_reqs, hv_info) -> SlottifierEntry:
+def calculate_slots_on_hv(flavor_name: str, flavor_reqs: Dict, hv_info: Dict) -> SlottifierEntry:
     """
     Helper function that calculates available slots for a flavor on a given hypervisor
     :param flavor_name: name of flavor
@@ -202,7 +202,7 @@ def get_openstack_resources(instance: str) -> Dict:
 
 
 def get_all_hv_info_for_aggregate(
-    aggregate, all_compute_services, all_hypervisors
+    aggregate: Dict, all_compute_services: List, all_hypervisors: List
 ) -> List:
     """
     helper function to get all useful info from hypervisors belonging to a given aggregate
@@ -215,28 +215,27 @@ def get_all_hv_info_for_aggregate(
 
     valid_hvs = []
     for host in aggregate["hosts"]:
-        host_compute_service = next(
-            (cs for cs in all_compute_services if cs["host"] == host), None
-        )
+
+        host_compute_service = None
+        for cs in all_compute_services:
+            if cs["host"] == host:
+                host_compute_service = cs
+
         if not host_compute_service:
             continue
 
-        hv = next(
-            (
-                hv
-                for hv in all_hypervisors
-                if host_compute_service["host"] == hv["name"]
-            ),
-            None,
-        )
-        if not hv:
+        hv_obj = None
+        for hv in all_hypervisors:
+            if host_compute_service["host"] == hv["name"]:
+                hv_obj = hv
+        if not hv_obj:
             continue
 
-        valid_hvs.append(get_hv_info(hv, aggregate, host_compute_service))
+        valid_hvs.append(get_hv_info(hv_obj, aggregate, host_compute_service))
     return valid_hvs
 
 
-def update_slots(flavors, host_info_list, slots_dict) -> Dict:
+def update_slots(flavors: List, host_info_list: List, slots_dict: Dict) -> Dict:
     """
     update total slots by calculating slots available for a set of flavors on a set of hosts
     :param flavors: a list of flavors

--- a/MonitoringTools/usr/local/bin/slottifier_entry.py
+++ b/MonitoringTools/usr/local/bin/slottifier_entry.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+
+@dataclass
+class SlottifierEntry:
+    """
+    A dataclass to hold slottifier information
+    :param slots_available: Number of slots available for a flavor
+    :param estimated_gpu_slots_used: Number of gpu slots currently used that could host this flavor
+        - estimated by amount of cores/mem already used by hvs as there's no way in openstack to find this out directly
+    :param max_gpu_slots_capacity: Number of gpus available on all compatible hypervisors to build this flavor on
+    :param max_gpu_slots_capacity_enabled: like max_gpu_slots_capacity, but only counting hosts with nova-compute
+    service enabled
+    """
+    slots_available: int = 0
+    estimated_gpu_slots_used: int = 0
+    max_gpu_slots_capacity: int = 0
+    max_gpu_slots_capacity_enabled: int = 0
+
+    def __add__(self, other):
+        """
+        dunder method to add two SlottifierEntry values together.
+        :param other: Another SlottifierEntry dataclass to add
+        :return: A SlottifierEntry dataclass where each attribute value from current dataclass and given dataclass are
+        added together
+        """
+        if not isinstance(other, SlottifierEntry):
+            raise TypeError(f"Unsupported operand type for +: '{type(self)}' and '{type(other)}'")
+
+        return SlottifierEntry(
+            *(
+                self_attr + other_attr for self_attr, other_attr
+                in zip(self.__dict__.values(), other.__dict__.values())
+            )
+        )

--- a/MonitoringTools/usr/local/bin/slottifier_entry.py
+++ b/MonitoringTools/usr/local/bin/slottifier_entry.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+
 @dataclass
 class SlottifierEntry:
     """
@@ -11,6 +12,7 @@ class SlottifierEntry:
     :param max_gpu_slots_capacity_enabled: like max_gpu_slots_capacity, but only counting hosts with nova-compute
     service enabled
     """
+
     slots_available: int = 0
     estimated_gpu_slots_used: int = 0
     max_gpu_slots_capacity: int = 0
@@ -24,11 +26,15 @@ class SlottifierEntry:
         added together
         """
         if not isinstance(other, SlottifierEntry):
-            raise TypeError(f"Unsupported operand type for +: '{type(self)}' and '{type(other)}'")
+            raise TypeError(
+                f"Unsupported operand type for +: '{type(self)}' and '{type(other)}'"
+            )
 
         return SlottifierEntry(
             *(
-                self_attr + other_attr for self_attr, other_attr
-                in zip(self.__dict__.values(), other.__dict__.values())
+                self_attr + other_attr
+                for self_attr, other_attr in zip(
+                    self.__dict__.values(), other.__dict__.values()
+                )
             )
         )

--- a/MonitoringTools/usr/local/bin/slottifier_entry.py
+++ b/MonitoringTools/usr/local/bin/slottifier_entry.py
@@ -31,10 +31,14 @@ class SlottifierEntry:
             )
 
         return SlottifierEntry(
-            *(
-                self_attr + other_attr
-                for self_attr, other_attr in zip(
-                    self.__dict__.values(), other.__dict__.values()
-                )
-            )
+            slots_available=self.slots_available + other.slots_available,
+
+            estimated_gpu_slots_used=self.estimated_gpu_slots_used
+            + other.estimated_gpu_slots_used,
+
+            max_gpu_slots_capacity=self.max_gpu_slots_capacity
+            + other.max_gpu_slots_capacity,
+
+            max_gpu_slots_capacity_enabled=self.max_gpu_slots_capacity_enabled
+            + other.max_gpu_slots_capacity_enabled,
         )


### PR DESCRIPTION
Add scripts that scrape info from openstack that we post to influxdb - and use in our grafana dashboards. 

TODO: 
- ~~Unit Tests~~
- Add docstrings to tests
- CI/CD
-  convert limits_to_influx to only using openstacksdk

updated version of #22 