### PR TITLE
BUG: fix various bugs with influxdb monitoring scripts

### DIFF
--- a/MonitoringTools/tests/test_service_status_to_influx.py
+++ b/MonitoringTools/tests/test_service_status_to_influx.py
@@ -267,7 +267,7 @@ def test_get_service_prop_string_with_int_props():
     when given int props it should suffix each property value with i
     """
     props = {"prop1": 1, "prop2": 2, "prop3": 3}
-    expected_result = 'prop1="1i",prop2="2i",prop3="3i"'
+    expected_result = "prop1=1i,prop2=2i,prop3=3i"
     assert get_service_prop_string(props) == expected_result
 
 

--- a/MonitoringTools/tests/test_slottifier.py
+++ b/MonitoringTools/tests/test_slottifier.py
@@ -54,19 +54,21 @@ def mock_service_fixture():
 
 @pytest.fixture(name="mock_aggregate")
 def mock_aggregate_fixture():
-    """fixture for setting up a mock aggregate"""
-
-    def _mock_aggregate(hosttype=None, gpu_num=None):
+    """ fixture for setting up a mock aggregate"""
+    def _mock_aggregate(hosttype=None, gpu_num=None, storagetype=None):
         """
         helper function for setting up mock aggregate
         :param hosttype: optional hosttype to set
         :param gpu_num: optional gpu_num to set
+        :param storagetype: optional storagetype to set
         """
         ag = {"metadata": {}}
         if hosttype:
             ag["metadata"]["hosttype"] = hosttype
         if gpu_num:
             ag["metadata"]["gpunum"] = gpu_num
+        if storagetype:
+            ag["metadata"]["local-storage-type"] = storagetype
         return ag
 
     return _mock_aggregate
@@ -76,11 +78,34 @@ def mock_aggregate_fixture():
 def mock_flavors_fixture():
     """fixture for setting up various mock flavors"""
     return [
-        {"id": 1, "extra_specs": {"aggregate_instance_extra_specs:hosttype": "A"}},
-        {"id": 2, "extra_specs": {"aggregate_instance_extra_specs:hosttype": "B"}},
+        {
+            "id": 1, "extra_specs": {
+                "aggregate_instance_extra_specs:hosttype": "A"
+            }
+        },
+        {
+            "id": 2, "extra_specs": {
+                "aggregate_instance_extra_specs:hosttype": "B"
+            }
+        },
         {"id": 3, "extra_specs": {}},
-        {"id": 4, "extra_specs": {"aggregate_instance_extra_specs:hosttype": "A"}},
-        {"id": 5, "extra_specs": {"aggregate_instance_extra_specs:hosttype": "C"}},
+        {
+            "id": 4, "extra_specs": {
+                "aggregate_instance_extra_specs:hosttype": "A"
+            }
+        },
+        {
+            "id": 5, "extra_specs": {
+                "aggregate_instance_extra_specs:hosttype": "C",
+                "aggregate_instance_extra_specs:local-storage-type": "1"
+            }
+        },
+        {
+            "id": 6, "extra_specs": {
+                "aggregate_instance_extra_specs:hosttype": "C",
+                "aggregate_instance_extra_specs:local-storage-type": "2"
+            }
+        }
     ]
 
 
@@ -197,6 +222,24 @@ def test_get_valid_flavors_with_non_matching_hosttype(
     matching aggregate hosttype
     """
     assert not get_valid_flavors_for_aggregate(mock_flavors_list, mock_aggregate("D"))
+
+
+def test_get_valid_flavors_with_storagetype(mock_flavors_list, mock_aggregate):
+    """
+    test get_valid_flavors_for_aggregate should return list of hvs with matching hosttype and storagetype
+    """
+    assert (
+        get_valid_flavors_for_aggregate(mock_flavors_list, mock_aggregate(hosttype="C", storagetype="1")) ==
+        [
+            {
+                "id": 5, "extra_specs": {
+                    "aggregate_instance_extra_specs:hosttype": "C",
+                    "aggregate_instance_extra_specs:local-storage-type": "1"
+                }
+            },
+        ]
+    )
+
 
 
 def test_convert_to_data_string_no_items():

--- a/MonitoringTools/tests/test_slottifier.py
+++ b/MonitoringTools/tests/test_slottifier.py
@@ -54,7 +54,8 @@ def mock_service_fixture():
 
 @pytest.fixture(name="mock_aggregate")
 def mock_aggregate_fixture():
-    """ fixture for setting up a mock aggregate"""
+    """fixture for setting up a mock aggregate"""
+
     def _mock_aggregate(hosttype=None, gpu_num=None, storagetype=None):
         """
         helper function for setting up mock aggregate
@@ -62,14 +63,14 @@ def mock_aggregate_fixture():
         :param gpu_num: optional gpu_num to set
         :param storagetype: optional storagetype to set
         """
-        ag = {"metadata": {}}
+        aggregate = {"metadata": {}}
         if hosttype:
-            ag["metadata"]["hosttype"] = hosttype
+            aggregate["metadata"]["hosttype"] = hosttype
         if gpu_num:
-            ag["metadata"]["gpunum"] = gpu_num
+            aggregate["metadata"]["gpunum"] = gpu_num
         if storagetype:
-            ag["metadata"]["local-storage-type"] = storagetype
-        return ag
+            aggregate["metadata"]["local-storage-type"] = storagetype
+        return aggregate
 
     return _mock_aggregate
 
@@ -78,34 +79,24 @@ def mock_aggregate_fixture():
 def mock_flavors_fixture():
     """fixture for setting up various mock flavors"""
     return [
-        {
-            "id": 1, "extra_specs": {
-                "aggregate_instance_extra_specs:hosttype": "A"
-            }
-        },
-        {
-            "id": 2, "extra_specs": {
-                "aggregate_instance_extra_specs:hosttype": "B"
-            }
-        },
+        {"id": 1, "extra_specs": {"aggregate_instance_extra_specs:hosttype": "A"}},
+        {"id": 2, "extra_specs": {"aggregate_instance_extra_specs:hosttype": "B"}},
         {"id": 3, "extra_specs": {}},
+        {"id": 4, "extra_specs": {"aggregate_instance_extra_specs:hosttype": "A"}},
         {
-            "id": 4, "extra_specs": {
-                "aggregate_instance_extra_specs:hosttype": "A"
-            }
+            "id": 5,
+            "extra_specs": {
+                "aggregate_instance_extra_specs:hosttype": "C",
+                "aggregate_instance_extra_specs:local-storage-type": "1",
+            },
         },
         {
-            "id": 5, "extra_specs": {
+            "id": 6,
+            "extra_specs": {
                 "aggregate_instance_extra_specs:hosttype": "C",
-                "aggregate_instance_extra_specs:local-storage-type": "1"
-            }
+                "aggregate_instance_extra_specs:local-storage-type": "2",
+            },
         },
-        {
-            "id": 6, "extra_specs": {
-                "aggregate_instance_extra_specs:hosttype": "C",
-                "aggregate_instance_extra_specs:local-storage-type": "2"
-            }
-        }
     ]
 
 
@@ -228,18 +219,17 @@ def test_get_valid_flavors_with_storagetype(mock_flavors_list, mock_aggregate):
     """
     test get_valid_flavors_for_aggregate should return list of hvs with matching hosttype and storagetype
     """
-    assert (
-        get_valid_flavors_for_aggregate(mock_flavors_list, mock_aggregate(hosttype="C", storagetype="1")) ==
-        [
-            {
-                "id": 5, "extra_specs": {
-                    "aggregate_instance_extra_specs:hosttype": "C",
-                    "aggregate_instance_extra_specs:local-storage-type": "1"
-                }
+    assert get_valid_flavors_for_aggregate(
+        mock_flavors_list, mock_aggregate(hosttype="C", storagetype="1")
+    ) == [
+        {
+            "id": 5,
+            "extra_specs": {
+                "aggregate_instance_extra_specs:hosttype": "C",
+                "aggregate_instance_extra_specs:local-storage-type": "1",
             },
-        ]
-    )
-
+        },
+    ]
 
 
 def test_convert_to_data_string_no_items():

--- a/MonitoringTools/tests/test_slottifier_entry.py
+++ b/MonitoringTools/tests/test_slottifier_entry.py
@@ -5,21 +5,21 @@ def test_add():
     """
     test that adding two SlottifierEntry dataclasses works properly
     """
-    a = SlottifierEntry(
+    fst = SlottifierEntry(
         slots_available=1,
         estimated_gpu_slots_used=1,
         max_gpu_slots_capacity=1,
         max_gpu_slots_capacity_enabled=1,
     )
 
-    b = SlottifierEntry(
+    snd = SlottifierEntry(
         slots_available=2,
         estimated_gpu_slots_used=3,
         max_gpu_slots_capacity=4,
         max_gpu_slots_capacity_enabled=5,
     )
 
-    assert a + b == SlottifierEntry(
+    assert fst + snd == SlottifierEntry(
         slots_available=3,
         estimated_gpu_slots_used=4,
         max_gpu_slots_capacity=5,

--- a/MonitoringTools/usr/local/bin/service_status_to_influx.py
+++ b/MonitoringTools/usr/local/bin/service_status_to_influx.py
@@ -97,10 +97,10 @@ def get_service_prop_string(service_dict: Dict) -> str:
     """
     stats_strings = []
     for stat, val in service_dict.items():
-        parsed_val = val
+        stats_string = f'{stat}="{val}"'
         if stat not in ["statetext", "statustext", "aggregate"]:
-            parsed_val = f"{val}i"
-        stats_strings.append(f'{stat}="{parsed_val}"')
+            stats_string = f"{stat}={val}i"
+        stats_strings.append(stats_string)
     return ",".join(stats_strings)
 
 

--- a/MonitoringTools/usr/local/bin/slottifier.py
+++ b/MonitoringTools/usr/local/bin/slottifier.py
@@ -92,10 +92,16 @@ def get_valid_flavors_for_aggregate(flavor_list: List, aggregate: Dict) -> List:
         ):
             continue
 
-        has_local_storage = "aggregate_instance_extra_specs:local-storage-type" in flavor["extra_specs"].keys()
+        has_local_storage = (
+            "aggregate_instance_extra_specs:local-storage-type"
+            in flavor["extra_specs"].keys()
+        )
 
         if (
-            has_local_storage and flavor["extra_specs"]["aggregate_instance_extra_specs:local-storage-type"]
+            has_local_storage
+            and flavor["extra_specs"][
+                "aggregate_instance_extra_specs:local-storage-type"
+            ]
             != hypervisor_storage_type
         ):
             continue
@@ -231,19 +237,19 @@ def get_all_hv_info_for_aggregate(
 
     valid_hvs = []
     for host in aggregate["hosts"]:
-
         host_compute_service = None
-        for cs in all_compute_services:
-            if cs["host"] == host:
-                host_compute_service = cs
+        for compute_service in all_compute_services:
+            if compute_service["host"] == host:
+                host_compute_service = compute_service
 
         if not host_compute_service:
             continue
 
         hv_obj = None
-        for hv in all_hypervisors:
-            if host_compute_service["host"] == hv["name"]:
-                hv_obj = hv
+        for hypervisor in all_hypervisors:
+            if host_compute_service["host"] == hypervisor["name"]:
+                hv_obj = hypervisor
+
         if not hv_obj:
             continue
 
@@ -262,9 +268,9 @@ def update_slots(flavors: List, host_info_list: List, slots_dict: Dict) -> Dict:
 
     for flavor in flavors:
         flavor_reqs = get_flavor_requirements(flavor)
-        for hv in host_info_list:
+        for hypervisor in host_info_list:
             slots_dict[flavor["name"]] += calculate_slots_on_hv(
-                flavor["name"], flavor_reqs, hv
+                flavor["name"], flavor_reqs, hypervisor
             )
     return slots_dict
 

--- a/MonitoringTools/usr/local/bin/slottifier.py
+++ b/MonitoringTools/usr/local/bin/slottifier.py
@@ -74,6 +74,7 @@ def get_valid_flavors_for_aggregate(flavor_list: List, aggregate: Dict) -> List:
     """
     valid_flavors = []
     hypervisor_hosttype = aggregate["metadata"].get("hosttype", None)
+    hypervisor_storage_type = aggregate["metadata"].get("local-storage-type", None)
 
     if not hypervisor_hosttype:
         return valid_flavors
@@ -90,6 +91,15 @@ def get_valid_flavors_for_aggregate(flavor_list: List, aggregate: Dict) -> List:
             != hypervisor_hosttype
         ):
             continue
+
+        has_local_storage = "aggregate_instance_extra_specs:local-storage-type" in flavor["extra_specs"].keys()
+
+        if (
+            has_local_storage and flavor["extra_specs"]["aggregate_instance_extra_specs:local-storage-type"]
+            != hypervisor_storage_type
+        ):
+            continue
+
         valid_flavors.append(flavor)
     return valid_flavors
 


### PR DESCRIPTION
slottifier now only selects hvs with matching storagetype and hosttype to calculate slots on

fix data string formatting for `service_status_to_influx.py` script