### PR TITLE
MAINT: Update to codecov v4 and use tokens for all

### DIFF
--- a/.github/workflows/MonitoringTools.yaml
+++ b/.github/workflows/MonitoringTools.yaml
@@ -39,7 +39,7 @@ jobs:
         run: cd MonitoringTools && python3 -m pytest . --cov-report xml:coverage.xml --cov
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./MonitoringTools/coverage.xml

--- a/.github/workflows/cloud_chatops.yaml
+++ b/.github/workflows/cloud_chatops.yaml
@@ -34,7 +34,7 @@ jobs:
         run: cd cloud_chatops && python3 -m pytest . --cov-report xml:coverage.xml --cov
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./cloud_chatops/coverage.xml

--- a/.github/workflows/prometheus_query_to_csv.yaml
+++ b/.github/workflows/prometheus_query_to_csv.yaml
@@ -36,7 +36,7 @@ jobs:
         run: cd prometheus_query_to_csv && python3 -m pytest . --cov-report xml:coverage.xml --cov
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./prometheus_query_to_csv/coverage.xml

--- a/.github/workflows/pynetbox.yaml
+++ b/.github/workflows/pynetbox.yaml
@@ -39,7 +39,7 @@ jobs:
         run: cd pynetbox_query && python3 -m pytest . --cov-report xml:coverage.xml --cov
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./pynetbox_query/coverage.xml

--- a/.github/workflows/rabbit_consumer.yaml
+++ b/.github/workflows/rabbit_consumer.yaml
@@ -43,11 +43,12 @@ jobs:
           cd OpenStack-Rabbit-Consumer && python -m coverage xml
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: OpenStack-Rabbit-Consumer/coverage.xml
           fail_ci_if_error: true
           flags: rabbit_consumer
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   push_dev_image_harbor:
     runs-on: ubuntu-latest

--- a/.github/workflows/reverse_ssl_cert_chain.yaml
+++ b/.github/workflows/reverse_ssl_cert_chain.yaml
@@ -39,7 +39,7 @@ jobs:
         run: cd reverse_ssl_cert_chain && python3 -m pytest . --cov-report xml:coverage.xml --cov
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./reverse_ssl_cert_chain/coverage.xml


### PR DESCRIPTION
Ensures we use codecov V4 and have a token for each build pipeline too