### PR TITLE
BUG: Workflow runs only on certain changes

### DIFF
--- a/.github/workflows/cloud_chatops.yaml
+++ b/.github/workflows/cloud_chatops.yaml
@@ -1,9 +1,13 @@
 name: CI/CD Cloud ChatOps
 
 on:
-  pull_request:
+  push:
     branches:
       - master
+  pull_request:
+    paths:
+      - "cloud_chatops/**"
+      - ".github/workflows/cloud_chatops.yaml"
 
 jobs:
   Pylint-Tests-Codecov:


### PR DESCRIPTION
The workflow was running on every PR which is wrong. It should run only when files in cloud_chatops dir are changed or the workflow itself