### PR TITLE
ENH: Changed rabbit harbor access

### DIFF
--- a/.github/workflows/rabbit_consumer.yaml
+++ b/.github/workflows/rabbit_consumer.yaml
@@ -64,8 +64,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: harbor.stfc.ac.uk
-          username: ${{ secrets.HARBOR_USERNAME }}
-          password: ${{ secrets.HARBOR_TOKEN }}
+          username: ${{ secrets.STAGING_HARBOR_USERNAME }}
+          password: ${{ secrets.STAGING_HARBOR_TOKEN }}
 
       - name: Set commit SHA for later
         id: commit_sha


### PR DESCRIPTION
New staging secrets have been added to the repo and so the dev push job should use these secrets