### PR TITLE
Cleanup - removing the push to dev job on the Rabbit Consumer Schedule workflow

### DIFF
--- a/.github/workflows/rabbit_consumer_schedule.yaml
+++ b/.github/workflows/rabbit_consumer_schedule.yaml
@@ -2,7 +2,6 @@ name: Rabbit Consumer Schedule
 
 # Incrementing the patch version on a schedule to pull latest containers dependencies.
 
-
 on:
   schedule: 
       - cron: "12 10 * * TUE" # Every Tuesday at 10.12am
@@ -40,38 +39,6 @@ jobs:
       - name: Prepare coverage
         run: |
           cd OpenStack-Rabbit-Consumer && python -m coverage xml
-
-  push_dev_image_harbor:
-    runs-on: ubuntu-latest
-    needs: test_and_lint
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Harbor
-        uses: docker/login-action@v2
-        with:
-          registry: harbor.stfc.ac.uk
-          username: ${{ secrets.HARBOR_USERNAME }}
-          password: ${{ secrets.HARBOR_TOKEN }}
-
-      - name: Set commit SHA for later
-        id: commit_sha
-        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
-      - name: Build and push to staging project
-        uses: docker/build-push-action@v3
-        with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: true
-          context: "{{defaultContext}}:OpenStack-Rabbit-Consumer"
-          tags: "harbor.stfc.ac.uk/stfc-cloud-staging/openstack-rabbit-consumer:${{ steps.commit_sha.outputs.sha_short }}"
-
-      - name: Inform of tagged name
-        run: echo "Image published to harbor.stfc.ac.uk/stfc-cloud-staging/openstack-rabbit-consumer:${{ steps.commit_sha.outputs.sha_short }}"
 
   push_release_image_harbor:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We don't need to push to the staging area since this is running on a schedule and no PRs will be made on this workflow. Therefore I removed it from the `rabbit_consumer_schedule.yaml` file only.
