### PR TITLE
ENH: Add a certbot role to setup let's encrypt certificates

### DIFF
--- a/grafana_monitoring/README.md
+++ b/grafana_monitoring/README.md
@@ -33,6 +33,6 @@ To replace the Aquilon configuration...
     ```
 7. If you need to make changes to any of the services' config you can run each role separately with their tags
     ```shell
-    ansible-playbook site.yaml --inventory staging/production --tags <grafana | haproxy | certbot>
+    ansible-playbook site.yaml --inventory <staging | production> --tags <grafana | haproxy | certbot>
     ```
    

--- a/grafana_monitoring/README.md
+++ b/grafana_monitoring/README.md
@@ -7,6 +7,9 @@ An Ansible playbook to deploy our staging / production Grafana instances. It ins
 To replace the Aquilon configuration...
 
 ## How?
+
+#### Note: You will need to have a floating IP with DNS and ports 80, 443 open. You must set up a load balancer and add the VM as a member to both pools beforehand.
+
 1. Clone this repository
     ```shell
     git clone https://github.com/stfc/SCD-OpenStack-Utils
@@ -23,16 +26,13 @@ To replace the Aquilon configuration...
     https://<your-domain>:443/login/generic_oauth
     ```
 4. Fill in the staging or production inventory with the credentials
-5. (Optional): Change the `grafana` group inventory hosts to whatever IP they are running on
-6. Copy your SSL certificate with name format `<your-domain>.crt` to `roles/haproxy/files/` and make sure the key is prepended to the top.
-7. Run the ansible playbook
+5. Change the `grafana` group inventory hosts to whatever IP the machine will be running on.
+6. Run the ansible playbook
     ```shell
-    ansible-playbook site.yaml --inventory staging/production
+    ansible-playbook site.yaml --inventory <staging | production>
     ```
-8. If you need to make changes to either the Grafana or HAProxy config you can run each role separately with their tags
+7. If you need to make changes to any of the services' config you can run each role separately with their tags
     ```shell
-    ansible-playbook site.yaml --inventory staging/production --tags grafana
-    # or
-    ansible-playbook site.yaml --inventory staging/production --tags haproxy
+    ansible-playbook site.yaml --inventory staging/production --tags <grafana | haproxy | certbot>
     ```
    

--- a/grafana_monitoring/roles/certbot/tasks/main.yml
+++ b/grafana_monitoring/roles/certbot/tasks/main.yml
@@ -1,0 +1,93 @@
+---
+- name: Install prerequisite packages
+  become: true
+  ansible.builtin.apt:
+    pkg:
+      - python3-venv
+      - libaugeas0
+    update_cache: true
+
+- name: Install certbot
+  become: true
+  ansible.builtin.pip:
+    name: certbot
+    virtualenv: /opt/certbot
+    virtualenv_command: python3 -m venv
+
+- name: Create a symbolic link for certbot
+  become: true
+  ansible.builtin.file:
+    src: /opt/certbot/bin/certbot
+    dest: /usr/bin/certbot
+    owner: root
+    group: root
+    state: link
+
+- name: Stop HAProxy
+  become: true
+  ansible.builtin.systemd_service:
+    state: stopped
+    name: haproxy.service
+
+- name: Check if certificate exists
+  become: true
+  ansible.builtin.stat:
+    path: /etc/haproxy/{{ domain }}.crt
+  register: certificate_file
+
+- name: Generate the certificate for the first time
+  become: true
+  ansible.builtin.shell: "certbot certonly --standalone --non-interactive --agree-tos --domains {{ domain }} -m cloud-support@stfc.ac.uk"
+  when: not certificate_file.stat.exists
+
+- name: Copy certificate for the first time
+  become: true
+  ansible.builtin.shell: "cat /etc/letsencrypt/live/{{ domain }}/privkey.pem /etc/letsencrypt/live/{{ domain }}/fullchain.pem > /etc/haproxy/{{ domain }}.crt"
+  when: not certificate_file.stat.exists
+
+- name: Create a cron job for the renewal of certificates
+  become: true
+  become_user: root
+  ansible.builtin.cron:
+    name: "Renew Let's Encrypt certificates"
+    minute: "0"
+    hour: "0,12"
+    day: "*"
+    job: "/opt/certbot/bin/python -c 'import random; import time; time.sleep(random.random() * 3600)' && sudo certbot renew -q"
+
+- name: Create a cron job for the upgrade of certbot
+  become: true
+  become_user: root
+  ansible.builtin.cron:
+    name: "Upgrade Certbot"
+    month: "*"
+    job: "sudo /opt/certbot/bin/pip install --upgrade certbot"
+
+- name: Create a cron job to copy certificate to haproxy directory
+  become: true
+  become_user: root
+  ansible.builtin.cron:
+    name: "Copy certificate"
+    minute: "1"
+    hour: "0,12"
+    day: "*"
+    job: "cat /etc/letsencrypt/live/{{ domain }}/privkey.pem /etc/letsencrypt/live/{{ domain }}/fullchain.pem > /etc/haproxy/{{ domain }}.crt"
+
+- name: Create a cron job to restart HAProxy to pick up new certificate
+  become: true
+  become_user: root
+  ansible.builtin.cron:
+    name: "Restart HAProxy to pick up new certificate"
+    minute: "3"
+    hour: "0,12"
+    day: "*"
+    job: "systemctl restart haproxy.service"
+
+- name: Restart HAProxy
+  become: true
+  ansible.builtin.systemd_service:
+    state: restarted
+    name: haproxy.service
+
+
+

--- a/grafana_monitoring/roles/haproxy/tasks/main.yml
+++ b/grafana_monitoring/roles/haproxy/tasks/main.yml
@@ -14,17 +14,15 @@
     group: haproxy
     mode: '0644'
 
-- name: Copy certificate
+- name: Check if certificate exists
   become: true
-  ansible.builtin.copy:
-    src: "{{ domain }}.crt"
-    dest: "/etc/haproxy/{{ domain }}.crt"
-    owner: root
-    group: haproxy
-    mode: '0644'
+  ansible.builtin.stat:
+    path: /etc/haproxy/{{ domain }}.crt
+  register: certificate_file
 
 - name: Make sure haproxy.service is running
   become: true
   ansible.builtin.systemd_service:
     state: restarted
     name: haproxy.service
+  when: certificate_file.stat.exists

--- a/grafana_monitoring/site.yml
+++ b/grafana_monitoring/site.yml
@@ -9,3 +9,6 @@
     - role: haproxy
       tags:
         - haproxy
+    - role: certbot
+      tags:
+        - certbot


### PR DESCRIPTION
We can no longer use certificates from DI so we are using let's encrypt as an alternative. LE certificates only last 90 days so we need to use certbot to automatically renew the certificates