### PR TITLE
BUG: Change trigger path for workflow

### DIFF
--- a/.github/workflows/chatops.yaml
+++ b/.github/workflows/chatops.yaml
@@ -5,11 +5,11 @@ on:
     branches:
       - master
     paths:
-      - "chatops_deployment/*"
+      - "chatops_deployment/**"
       - ".github/workflows/chatops.yaml"
   pull_request:
     paths:
-      - "chatops_deployment/*"
+      - "chatops_deployment/**"
       - ".github/workflows/chatops.yaml"
 
 jobs:


### PR DESCRIPTION
Changing the path for the workflow to trigger on. * only checks the current directory. Changing to ** to recursively check directories