### PR TITLE
ENH: Add systemd exporter to hosts

### DIFF
--- a/chatops_deployment/ansible/configure.yml
+++ b/chatops_deployment/ansible/configure.yml
@@ -15,6 +15,14 @@
       tags:
         - chatops
 
+- name: Set up systemd exporters
+  hosts: all
+  remote_user: ubuntu
+  roles:
+    - role: systemd_exporter
+      tags:
+        - systemd_exporter
+
 - name: Configure Grafana
   hosts: grafana
   remote_user: ubuntu

--- a/chatops_deployment/ansible/group_vars/all/vars.yml
+++ b/chatops_deployment/ansible/group_vars/all/vars.yml
@@ -1,2 +1,3 @@
 domain: "dev-cloud-chatops.nubes.rl.ac.uk"
 chatops_custom_api_token: "{{ vault_chatops_custom_api_token }}"
+systemd_exporter_version: "0.7.0"

--- a/chatops_deployment/ansible/roles/prometheus/files/rules.yml
+++ b/chatops_deployment/ansible/roles/prometheus/files/rules.yml
@@ -9,3 +9,12 @@ groups:
         annotations:
           summary: "ChatOps container is detected down on {{ $labels.instance }}"
           description: "Container has been not running for more than 10 seconds."
+
+      - alert: SystemdServiceDown
+        expr: systemd_unit_state{name=~"grafana-server.service|haproxy.service",state=~"failed|inactive"} == 1
+        for: 30s
+        labels:
+          severity: critical
+        annotations:
+          summary: "Systemd service {{ $labels.name }} on host {{ $labels.instance }} is in state {{ $labels.state }}."
+          description: "Systemd service has been in failed state for 30s."

--- a/chatops_deployment/ansible/roles/systemd_exporter/files/systemd-exporter.service
+++ b/chatops_deployment/ansible/roles/systemd_exporter/files/systemd-exporter.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Systemd Exporter Service
+Documentation=https://github.com/prometheus-community/systemd_exporter
+After=network-online.target
+
+[Service]
+User=systemd-exporter
+Group=systemd-exporter
+Restart=on-failure
+ExecStart=/opt/systemd-exporter/systemd_exporter \
+--web.telemetry-path="/"
+StandardOutput=append:/opt/systemd-exporter/systemd-exporter.log
+StandardError=append:/opt/systemd-exporter/systemd-exporter.log
+
+[Install]
+WantedBy=multi-user.target

--- a/chatops_deployment/ansible/roles/systemd_exporter/tasks/main.yml
+++ b/chatops_deployment/ansible/roles/systemd_exporter/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+- name: Create systemd-exporter group
+  become: true
+  ansible.builtin.group:
+    name: systemd-exporter
+    state: present
+
+- name: Add ubuntu to systemd-exporter group
+  become: true
+  ansible.builtin.user:
+    name: ubuntu
+    groups: systemd-exporter
+    append: true
+
+- name: Reset connection for group changes
+  ansible.builtin.meta: reset_connection
+
+- name: Create a systemd-exporter user
+  become: true
+  ansible.builtin.user:
+    name: systemd-exporter
+    create_home: false
+    group: systemd-exporter
+    system: true
+
+- name: Download and extract systemd-exporter
+  become: true
+  ansible.builtin.unarchive:
+    src: "
+      https://github.com/prometheus-community/systemd_exporter/releases/download/\
+      v{{ systemd_exporter_version }}/systemd_exporter-{{ systemd_exporter_version }}.linux-amd64.tar.gz
+    "
+    dest: /tmp
+    remote_src: true
+    creates: "/tmp/systemd_exporter-{{ systemd_exporter_version }}.linux-amd64"
+    mode: "0774"
+
+- name: Move systemd-exporter binaries
+  become: true
+  ansible.builtin.copy:
+    src: "/tmp/systemd_exporter-{{ systemd_exporter_version }}.linux-amd64/"
+    dest: "/opt/systemd-exporter"
+    mode: preserve
+    owner: systemd-exporter
+    group: systemd-exporter
+    remote_src: true
+
+- name: Copy systemd-exporter service file
+  become: true
+  ansible.builtin.copy:
+    src: systemd-exporter.service
+    dest: /etc/systemd/system/systemd-exporter.service
+    owner: systemd-exporter
+    group: systemd-exporter
+    mode: "0774"
+
+- name: Start systemd-exporter service
+  become: true
+  ansible.builtin.systemd_service:
+    name: systemd-exporter.service
+    state: restarted
+    daemon_reload: true
+    enabled: true

--- a/chatops_deployment/terraform/modules/networking/main.tf
+++ b/chatops_deployment/terraform/modules/networking/main.tf
@@ -134,3 +134,43 @@ resource "openstack_networking_secgroup_rule_v2" "loadbalancer_prometheus" {
   remote_ip_prefix  = "192.168.100.0/22"
   security_group_id = openstack_networking_secgroup_v2.loadbalancer.id
 }
+
+resource "openstack_networking_secgroup_rule_v2" "systemd_exporter_prometheus" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 9558
+  port_range_max    = 9558
+  remote_ip_prefix  = "192.168.100.0/22"
+  security_group_id = openstack_networking_secgroup_v2.prometheus.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "systemd_exporter_chatops" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 9558
+  port_range_max    = 9558
+  remote_ip_prefix  = "192.168.100.0/22"
+  security_group_id = openstack_networking_secgroup_v2.chatops.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "systemd_exporter_grafana" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 9558
+  port_range_max    = 9558
+  remote_ip_prefix  = "192.168.100.0/22"
+  security_group_id = openstack_networking_secgroup_v2.grafana.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "systemd_exporter_loadbalancer" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 9558
+  port_range_max    = 9558
+  remote_ip_prefix  = "192.168.100.0/22"
+  security_group_id = openstack_networking_secgroup_v2.loadbalancer.id
+}


### PR DESCRIPTION
This enables us to put alerting in place for services that are running as a service on systemd. Such as Grafana, Elasticsearch and Logstash...

Adds the port 9558 as a rule to each VMs security groups.