### PR TITLE
MAINT: Change the dev grafana IRIS IAM role from Editor to Admin

### DIFF
--- a/grafana_monitoring/roles/grafana/templates/grafana.ini.j2
+++ b/grafana_monitoring/roles/grafana/templates/grafana.ini.j2
@@ -28,5 +28,5 @@ admin_password="{{ grafana_admin_password }}"
 
 {% if inventory_hostname.startswith("dev") %}
 [users]
-auto_assign_org_role=Editor
+auto_assign_org_role=Admin
 {% endif %}


### PR DESCRIPTION
Changing the default role to admin so people can make changes to datasources