### PR TITLE
Add Elastic stack VM

### DIFF
--- a/chatops_deployment/ansible/host_vars/localhost/vars.yml
+++ b/chatops_deployment/ansible/host_vars/localhost/vars.yml
@@ -1,4 +1,5 @@
 terraform_deployment: chatops-2025-04-22
 terraform_external_network_id: 5283f642-8bd8-48b6-8608-fa3006ff4539
 terraform_floating_ip: 130.246.83.230
+terraform_elasticsearch_volume_id: 3a4c7ddd-13ec-4beb-80a9-589c86a36f08
 bastion_key_passphrase: "{{ vault_bastion_key_passphrase }}"

--- a/chatops_deployment/ansible/roles/terraform/templates/hosts.ini.j2
+++ b/chatops_deployment/ansible/roles/terraform/templates/hosts.ini.j2
@@ -19,16 +19,26 @@
 [prometheus:vars]
 loadbalancer_private_ip="{{ terraform_output.outputs.loadbalancer_private_ip.value }}"
 
+[elastic]
+{% for ip in terraform_output.outputs.elastic_host_ips.value %}
+{{ ip }}
+{% endfor %}
+
+[elastic:vars]
+elasticsearch_device="{{ terraform_output.outputs.elasticsearch_device.value }}"
+
 [monitoring]
 [monitoring:children]
 prometheus
 grafana
+elastic
 
 [private]
 [private:children]
 prometheus
 grafana
 chatops
+elastic
 
 [private:vars]
 ansible_ssh_common_args='-o ProxyCommand="ssh -p 22 -W %h:%p -q ubuntu@{{ terraform_floating_ip }}"'

--- a/chatops_deployment/ansible/roles/terraform/templates/terraform.tfvars.j2
+++ b/chatops_deployment/ansible/roles/terraform/templates/terraform.tfvars.j2
@@ -1,3 +1,4 @@
 deployment="{{ terraform_deployment }}"
 external_network_id="{{ terraform_external_network_id }}"
 floating_ip="{{ terraform_floating_ip }}"
+elasticsearch_volume_id="{{ terraform_elasticsearch_volume_id }}"

--- a/chatops_deployment/terraform/main.tf
+++ b/chatops_deployment/terraform/main.tf
@@ -24,9 +24,11 @@ module "compute" {
   grafana_secgroup      = module.networking.grafana_secgroup
   chatops_secgroup      = module.networking.chatops_secgroup
   prometheus_secgroup   = module.networking.prometheus_secgroup
+  elasticsearch_secgroup   = module.networking.elasticsearch_secgroup
   loadbalancer_secgroup = module.networking.loadbalancer_secgroup
   private_network       = module.networking.private_network
   private_subnet        = module.networking.private_subnet
   floating_ip           = var.floating_ip
   deployment            = var.deployment
+  elasticsearch_volume_id = var.elasticsearch_volume_id
 }

--- a/chatops_deployment/terraform/modules/compute/main.tf
+++ b/chatops_deployment/terraform/modules/compute/main.tf
@@ -44,6 +44,24 @@ resource "openstack_compute_instance_v2" "prometheus" {
   depends_on = [var.private_subnet]
 }
 
+resource "openstack_compute_instance_v2" "elastic" {
+  name            = "elasticsearch-host-${var.deployment}"
+  image_name      = "ubuntu-jammy-22.04-nogui"
+  flavor_name     = "l3.tiny"
+  key_pair        = openstack_compute_keypair_v2.bastion_keypair.name
+  security_groups = ["default", var.elasticsearch_secgroup.name]
+
+  network {
+    name = var.private_network.name
+  }
+  depends_on = [var.private_subnet]
+}
+
+resource "openstack_compute_volume_attach_v2" "elasticsearch_volume" {
+  instance_id = openstack_compute_instance_v2.elastic.id
+  volume_id = var.elasticsearch_volume_id
+}
+
 resource "openstack_compute_instance_v2" "chatops" {
   name            = "chatops-host-${var.deployment}"
   image_name      = "ubuntu-jammy-22.04-nogui"

--- a/chatops_deployment/terraform/modules/compute/outputs.tf
+++ b/chatops_deployment/terraform/modules/compute/outputs.tf
@@ -10,6 +10,14 @@ output "prometheus_host_ips" {
   value = openstack_compute_instance_v2.prometheus.*.access_ip_v4
 }
 
+output "elastic_host_ips" {
+  value = openstack_compute_instance_v2.elastic.*.access_ip_v4
+}
+
 output "loadbalancer_host_ip" {
   value = openstack_compute_instance_v2.loadbalancer.access_ip_v4
+}
+
+output "elasticsearch_device" {
+  value = openstack_compute_volume_attach_v2.elasticsearch_volume.device
 }

--- a/chatops_deployment/terraform/modules/compute/variables.tf
+++ b/chatops_deployment/terraform/modules/compute/variables.tf
@@ -2,7 +2,9 @@ variable "deployment" {}
 variable "grafana_secgroup" {}
 variable "chatops_secgroup" {}
 variable "prometheus_secgroup" {}
+variable "elasticsearch_secgroup" {}
 variable "loadbalancer_secgroup" {}
 variable "private_network" {}
 variable "floating_ip" {}
 variable "private_subnet" {}
+variable "elasticsearch_volume_id" {}

--- a/chatops_deployment/terraform/modules/networking/main.tf
+++ b/chatops_deployment/terraform/modules/networking/main.tf
@@ -90,6 +90,31 @@ resource "openstack_networking_secgroup_rule_v2" "prometheus" {
   security_group_id = openstack_networking_secgroup_v2.prometheus.id
 }
 
+resource "openstack_networking_secgroup_v2" "elasticsearch" {
+  name        = "elasticsearch-${var.deployment}"
+  description = "ElasticSearch host security group."
+}
+
+resource "openstack_networking_secgroup_rule_v2" "logstash" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 5044
+  port_range_max    = 5044
+  remote_ip_prefix  = "192.168.100.0/22"
+  security_group_id = openstack_networking_secgroup_v2.elasticsearch.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "kibana" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 5601
+  port_range_max    = 5601
+  remote_ip_prefix  = "192.168.100.0/22"
+  security_group_id = openstack_networking_secgroup_v2.elasticsearch.id
+}
+
 resource "openstack_networking_secgroup_rule_v2" "alertmanager" {
   direction         = "ingress"
   ethertype         = "IPv4"

--- a/chatops_deployment/terraform/modules/networking/outputs.tf
+++ b/chatops_deployment/terraform/modules/networking/outputs.tf
@@ -10,6 +10,10 @@ output "prometheus_secgroup" {
   value = openstack_networking_secgroup_v2.prometheus
 }
 
+output "elasticsearch_secgroup" {
+  value = openstack_networking_secgroup_v2.elasticsearch
+}
+
 output "loadbalancer_secgroup" {
   value = openstack_networking_secgroup_v2.loadbalancer
 }

--- a/chatops_deployment/terraform/outputs.tf
+++ b/chatops_deployment/terraform/outputs.tf
@@ -9,6 +9,9 @@ output "chatops_host_ips" {
 output "prometheus_host_ips" {
   value = module.compute.prometheus_host_ips
 }
+output "elastic_host_ips" {
+  value = module.compute.elastic_host_ips
+}
 
 output "loadbalancer_host_ips" {
   value = var.floating_ip
@@ -16,4 +19,8 @@ output "loadbalancer_host_ips" {
 
 output "loadbalancer_private_ip" {
   value = module.compute.loadbalancer_host_ip
+}
+
+output "elasticsearch_device" {
+  value = module.compute.elasticsearch_device
 }

--- a/chatops_deployment/terraform/variables.tf
+++ b/chatops_deployment/terraform/variables.tf
@@ -12,3 +12,8 @@ variable "external_network_id" {
   type        = string
   description = "ID of the external network in your project."
 }
+
+variable "elasticsearch_volume_id" {
+  type        = string
+  description = "ID of the elasticsearch volume in your project."
+}


### PR DESCRIPTION
Adding a new VM to the Terraform configuration to host the Elastic "ELK" stack. Also, creates security groups for the correct ports needed by this service and attaches a volume to the VM to be used as persistent database storage.