### PR TITLE
MAINT: Remove old repository not in use anymore

### DIFF
--- a/chatops_deployment/ansible/dev/group_vars/chatops/vars.yml
+++ b/chatops_deployment/ansible/dev/group_vars/chatops/vars.yml
@@ -2,7 +2,6 @@
 chatops_image: "harbor.stfc.ac.uk/stfc-cloud/cloud-chatops:8.0.1"
 chatops_github_repos:
   stfc:
-    - cloud-deployed-apps
     - st2-cloud-pack
     - cloud-grafana-dashboards
     - cloud-pe-jupyterhub


### PR DESCRIPTION
Removing this repo as we don't use it anymore and it keeps our code cleaner.

This is tested to work in development.