### PR TITLE
ENH: Allow user access to our Grafana instance

### DIFF
--- a/grafana_monitoring/roles/grafana/templates/cloud_datasource.yaml.j2
+++ b/grafana_monitoring/roles/grafana/templates/cloud_datasource.yaml.j2
@@ -1,6 +1,35 @@
 apiVersion: 1
 prune: true
 datasources:
+# These are our datasources safe for public query
+  - name: RemoteWritePrometheus
+    type: prometheus
+    uid: "remote_write_prometheus"
+    access: proxy
+    url: http://130.246.83.213:9090
+    isDefault: false
+    basicAuth: true
+    basicAuthUser: {{ remote_write_prometheus_username }}
+    secureJsonData:
+      basicAuthPassword: {{ remote_write_prometheus_password }}
+  
+  - name: DevCloudInfluxDB
+    type: influxdb
+    access: proxy
+    uid: "dev_openstack_grafana"
+    user: {{ dev_influx_username }}
+    url: "http://172.16.110.169:8086"
+    jsonData:
+      dbName : "cloud"
+      httpMode: POST
+      timeInterval: "60"
+      maxSeries: 200
+    secureJsonData:
+      password: {{ dev_influx_password }}
+
+# These datasources should not be queried by the public.
+# That's why they are only on the dev instance
+{% if inventory_hostname.startswith("dev") %}
   - name: CloudInfluxDB
     type: influxdb
     access: proxy
@@ -58,20 +87,6 @@ datasources:
     secureJsonData:
       basicAuthPassword: {{ meerkat_db_password }}
 
-  - name: DevCloudInfluxDB
-    type: influxdb
-    access: proxy
-    uid: "dev_openstack_grafana"
-    user: {{ dev_influx_username }}
-    url: "http://172.16.110.169:8086"
-    jsonData:
-      dbName : "cloud"
-      httpMode: POST
-      timeInterval: "60"
-      maxSeries: 200
-    secureJsonData:
-      password: {{ dev_influx_password }}
-
   - name: DevChatOps
     type: prometheus
     uid: "dev-chatops"
@@ -102,13 +117,4 @@ datasources:
     isDefault: false
     basicAuth: false
 
-  - name: RemoteWritePrometheus
-    type: prometheus
-    uid: "remote_write_prometheus"
-    access: proxy
-    url: http://130.246.83.213:9090
-    isDefault: false
-    basicAuth: true
-    basicAuthUser: {{ remote_write_prometheus_username }}
-    secureJsonData:
-      basicAuthPassword: {{ remote_write_prometheus_password }}
+{% endif %}

--- a/grafana_monitoring/roles/grafana/templates/grafana.ini.j2
+++ b/grafana_monitoring/roles/grafana/templates/grafana.ini.j2
@@ -17,15 +17,10 @@ auth_url = https://iris-iam.stfc.ac.uk/authorize
 token_url = https://iris-iam.stfc.ac.uk/token
 api_url = https://iris-iam.stfc.ac.uk/userinfo
 groups_attribute_path = groups[*]
-allowed_groups = "stfc-cloud/team,stfc-cloud/admins"
+allowed_groups = "stfc-cloud/team,stfc-cloud/admins,stfc-cloud/users"
 
-# Only apply role changes on dev so we can edit datasources and dashboards before pushing changes to prod.
-{% if inventory_hostname.startswith("dev") %}
 role_attribute_path=contains(groups[*], 'stfc-cloud/admins') && 'Admin' || contains(groups[*], 'stfc-cloud/team') && 'Editor' || 'Viewer'
-{% else %}
-# Keep role for all users as Viewer on production.
-role_attribute_path='Viewer'
-{% endif %}
+
 
 [log]
 # Raise the log level as the default is "info"

--- a/grafana_monitoring/roles/grafana/templates/provision_dashboards.sh.j2
+++ b/grafana_monitoring/roles/grafana/templates/provision_dashboards.sh.j2
@@ -15,3 +15,9 @@ BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$BRANCH_NAME" == "{{ grafana_dashboards_branch }}" ]]; then
    git fetch && git reset --h origin/{{ grafana_dashboards_branch }}
 fi
+
+{% if inventory_hostname.startswith("grafana") %}
+for DIR in $(ls -l | grep -v cloud_dashboard.yaml | grep -v Slots-Available | grep -v total | awk -F' ' '{ print $NF }'); do rm -r $DIR; done
+mv Slots-Available/openstack_slots_available.json .
+rm -r Slots-Available
+{% endif %}


### PR DESCRIPTION
This commit changes the deployment of our 2 Grafana instances. Going forward the production Grafana will be accessible by users. To make this the case, IRIS IAM users a part of the `stfc-cloud/users` will be able to authenticate. All datasources except those containing non-sensitive information have been removed. All dashboards except the slots available have been removed as they will no longer function.

The development instance will continue to contain all datasources and dashboards for the cloud team usage.