### PR TITLE
MAINT: Change log level to info

### DIFF
--- a/grafana_monitoring/roles/grafana/templates/grafana.ini.j2
+++ b/grafana_monitoring/roles/grafana/templates/grafana.ini.j2
@@ -23,8 +23,7 @@ role_attribute_path=contains(groups[*], 'stfc-cloud/admins') && 'Admin' || conta
 
 
 [log]
-# Raise the log level as the default is "info"
-log_level = critical
+log_level = info
 
 [security]
 admin_password="{{ grafana_admin_password }}"


### PR DESCRIPTION
By mistake the log level is set to critical. This will cause Grafana to only output logs at that level so we miss out on all other logs such as info warning and error.