### PR TITLE
BUG: Change allowed groups for dev

### DIFF
--- a/grafana_monitoring/roles/grafana/templates/grafana.ini.j2
+++ b/grafana_monitoring/roles/grafana/templates/grafana.ini.j2
@@ -17,7 +17,12 @@ auth_url = https://iris-iam.stfc.ac.uk/authorize
 token_url = https://iris-iam.stfc.ac.uk/token
 api_url = https://iris-iam.stfc.ac.uk/userinfo
 groups_attribute_path = groups[*]
+{% if inventory_hostname.startswith("grafana") %}
 allowed_groups = "stfc-cloud/team,stfc-cloud/admins,stfc-cloud/users"
+{% else %}
+allowed_groups = "stfc-cloud/team,stfc-cloud/admins"
+{% endif %}
+
 
 role_attribute_path=contains(groups[*], 'stfc-cloud/admins') && 'Admin' || contains(groups[*], 'stfc-cloud/team') && 'Editor' || 'Viewer'
 


### PR DESCRIPTION
We should not allow users access to the dev grafana. The config needs this update to make a different config for dev and prod

This fixes a mistake made in #276 