### PR TITLE
BUG: Move dashboard into folder

### DIFF
--- a/grafana_monitoring/roles/grafana/templates/provision_dashboards.sh.j2
+++ b/grafana_monitoring/roles/grafana/templates/provision_dashboards.sh.j2
@@ -18,6 +18,7 @@ fi
 
 {% if inventory_hostname.startswith("grafana") %}
 for DIR in $(ls -l | grep -v cloud_dashboard.yaml | grep -v Slots-Available | grep -v total | awk -F' ' '{ print $NF }'); do rm -r $DIR; done
-mv Slots-Available/openstack_slots_available.json .
+mkdir "Public"
+mv Slots-Available/openstack_slots_available.json Public
 rm -r Slots-Available
 {% endif %}


### PR DESCRIPTION
The "general" or top level directory in Grafana dashboards is readable only by admins. This means users cannot see the dashboards. Creating this "Public" subfolder allows it to be visible to editors and viewers.