### PR TITLE
Modify "PrometheusRemoteWrite" datasource setting

### DIFF
--- a/grafana_monitoring/roles/grafana/templates/cloud_datasource.yaml.j2
+++ b/grafana_monitoring/roles/grafana/templates/cloud_datasource.yaml.j2
@@ -10,6 +10,8 @@ datasources:
     isDefault: false
     basicAuth: true
     basicAuthUser: {{ remote_write_prometheus_username }}
+    jsonData:
+      timeout: 120
     secureJsonData:
       basicAuthPassword: {{ remote_write_prometheus_password }}
   


### PR DESCRIPTION
Increase the HTTP request timeout to 120s.
For VM Power & Carbon dashboard, if the time range is above 48 hours, panels throw error 504 Gateway Timeout. This is a fix to prevent query timeout while dashboard is loading data