### PR TITLE
Change RemoteWritePrometheus datasource setting

### DIFF
--- a/grafana_monitoring/roles/grafana/templates/cloud_datasource.yaml.j2
+++ b/grafana_monitoring/roles/grafana/templates/cloud_datasource.yaml.j2
@@ -11,7 +11,9 @@ datasources:
     basicAuth: true
     basicAuthUser: {{ remote_write_prometheus_username }}
     jsonData:
-      timeout: 120
+      timeout: "120"
+      timeInterval: "120"
+      cacheLevel: "High"
     secureJsonData:
       basicAuthPassword: {{ remote_write_prometheus_password }}
   

--- a/grafana_monitoring/roles/grafana/templates/grafana.ini.j2
+++ b/grafana_monitoring/roles/grafana/templates/grafana.ini.j2
@@ -32,3 +32,6 @@ log_level = info
 
 [security]
 admin_password="{{ grafana_admin_password }}"
+
+[dataproxy]
+timeout = 1200

--- a/grafana_monitoring/roles/grafana/templates/grafana.ini.j2
+++ b/grafana_monitoring/roles/grafana/templates/grafana.ini.j2
@@ -28,7 +28,7 @@ role_attribute_path=contains(groups[*], 'stfc-cloud/admins') && 'Admin' || conta
 
 
 [log]
-log_level = info
+log_level = debug
 
 [security]
 admin_password="{{ grafana_admin_password }}"


### PR DESCRIPTION
Change timeout value from number to string according to grafana docs 
Change cacheLevel and timeInterval
Work to fix the timeout 504 issue on VM Power & Carbon dashboard