### PR TITLE
Fix Grafana dashboard query timeout

### DIFF
--- a/grafana_monitoring/roles/haproxy/templates/haproxy.cfg.j2
+++ b/grafana_monitoring/roles/haproxy/templates/haproxy.cfg.j2
@@ -3,10 +3,10 @@ global
 
 defaults
   mode http
-  timeout client 10s
-  timeout connect 5s
-  timeout server 10s
-  timeout http-request 10s
+  timeout client 120s
+  timeout connect 10s
+  timeout server 120s
+  timeout http-request 120s
   log global
 
 frontend stats


### PR DESCRIPTION
For VM Power & Carbon dashboard, when the time range is more than 2 days, the dashboard error 504 Gateway Timeout Long running Prometheus queries were failing after 10s before reaching the datasource timeout configuration. So increase HAProxy timeout to allow the queries to complete.