### PR TITLE
BUG: Fix script deleting non empty directory

### DIFF
--- a/grafana_monitoring/roles/grafana/templates/provision_dashboards.sh.j2
+++ b/grafana_monitoring/roles/grafana/templates/provision_dashboards.sh.j2
@@ -21,5 +21,5 @@ for DIR in $(ls -l | grep -v cloud_dashboard.yaml | grep -v Slots-Available | gr
 mkdir "Public"
 mv Slots-Available/openstack_slots_available.json Public
 mv Virtual-Machines/* Public
-rm -d Slots-Available Virtual-Machines
+rm -rd Slots-Available Virtual-Machines
 {% endif %}


### PR DESCRIPTION
There are some dashboards in this folder that we do not want public. Using -r will delete these.